### PR TITLE
test out bump allocator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -635,6 +635,7 @@ version = "0.0.1"
 dependencies = [
  "anyhow",
  "arrow2",
+ "bumpalo",
  "criterion",
  "geo",
  "geodesy",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ arrow2 = { version = "0.17" }
 # TODO: properly feature gate this
 rstar = { version = "0.10" }
 geodesy = { version = "0.10", optional = true }
+bumpalo = { version = "3", features = ["collections"] }
 
 [dev-dependencies]
 arrow2 = { version = "0.17", features = [

--- a/src/algorithm/geo/simplify.rs
+++ b/src/algorithm/geo/simplify.rs
@@ -1,4 +1,5 @@
 use crate::array::*;
+use bumpalo::collections::CollectIn;
 use geo::Simplify as _Simplify;
 
 /// Simplifies a geometry.
@@ -76,6 +77,18 @@ iter_geo_impl!(LineStringArray, geo::LineString);
 iter_geo_impl!(PolygonArray, geo::Polygon);
 iter_geo_impl!(MultiLineStringArray, geo::MultiLineString);
 iter_geo_impl!(MultiPolygonArray, geo::MultiPolygon);
+
+pub fn simplify(arr: PolygonArray, epsilon: &f64) -> PolygonArray {
+    use bumpalo::{collections::Vec, Bump};
+    let bump = Bump::new();
+
+    let output_geoms: Vec<Option<geo::Polygon>> = arr
+        .iter_geo()
+        .map(|maybe_g| maybe_g.map(|geom| geom.simplify(epsilon)))
+        .collect_in(&bump);
+
+    output_geoms.into()
+}
 
 #[cfg(test)]
 mod tests {

--- a/src/array/polygon/array.rs
+++ b/src/array/polygon/array.rs
@@ -333,6 +333,13 @@ impl From<Vec<geo::Polygon>> for PolygonArray {
     }
 }
 
+impl From<bumpalo::collections::Vec<'_, Option<geo::Polygon>>> for PolygonArray {
+    fn from(value: bumpalo::collections::Vec<Option<geo::Polygon>>) -> Self {
+        let mut_arr: MutablePolygonArray = value.into();
+        mut_arr.into()
+    }
+}
+
 /// Polygon and MultiLineString have the same layout, so enable conversions between the two to
 /// change the semantic type
 impl From<PolygonArray> for MultiLineStringArray {


### PR DESCRIPTION
_In theory_ using a bump allocator should have potential for performance gains. [DuckDB Spatial uses one](https://github.com/duckdblabs/duckdb_spatial#per-thread-arena-allocation-for-geometry-objects) for its operations as well. 

I really want to benchmark this before moving forward. It would also be cleaner to dedupe constructing geometry arrays from:

- `Vec<geo::Polygon>`
- `Vec<Option<geo::Polygon>>`
- `bumpalo::collections::Vec<geo::Polygon>`
- `bumpalo::collections::Vec<Option<geo::Polygon>>`