### PR TITLE
RectArray

### DIFF
--- a/js/src/array/geometry.rs
+++ b/js/src/array/geometry.rs
@@ -67,6 +67,7 @@ impl GeometryArray {
             geoarrow::array::GeometryArray::MultiLineString(_) => GeometryType::MultiLineString,
             geoarrow::array::GeometryArray::MultiPolygon(_) => GeometryType::MultiPolygon,
             geoarrow::array::GeometryArray::WKB(_) => unimplemented!(),
+            geoarrow::array::GeometryArray::Rect(_) => unimplemented!(),
         }
     }
 }

--- a/src/algorithm/geo/dimensions.rs
+++ b/src/algorithm/geo/dimensions.rs
@@ -70,6 +70,7 @@ impl<O: Offset> HasDimensions for GeometryArray<O> {
             GeometryArray::MultiPoint(arr) => HasDimensions::is_empty(arr),
             GeometryArray::MultiLineString(arr) => HasDimensions::is_empty(arr),
             GeometryArray::MultiPolygon(arr) => HasDimensions::is_empty(arr),
+            _ => todo!(),
         }
     }
 }

--- a/src/algorithm/geo/utils.rs
+++ b/src/algorithm/geo/utils.rs
@@ -39,6 +39,7 @@ macro_rules! __geometry_array_delegate_impl_helper {
                         $enum::MultiLineString(g) => g.$func_name($($arg_name),*).into(),
                         $enum::MultiPolygon(g) => g.$func_name($($arg_name),*).into(),
                         // $enum::GeometryCollection(g) => g.$func_name($($arg_name),*).into(),
+                        $enum::Rect(_g) => todo!(),
                         // $enum::Rect(g) => g.$func_name($($arg_name),*).into(),
                         // $enum::Triangle(g) => g.$func_name($($arg_name),*).into(),
                     }

--- a/src/algorithm/geodesy/reproject.rs
+++ b/src/algorithm/geodesy/reproject.rs
@@ -130,5 +130,6 @@ pub fn reproject<O: Offset>(
                 arr.clone().with_coords(new_coords),
             ))
         }
+        GeometryArray::Rect(_arr) => todo!(),
     }
 }

--- a/src/array/geometry/array.rs
+++ b/src/array/geometry/array.rs
@@ -6,7 +6,7 @@ use rstar::RTree;
 
 use crate::array::{
     LineStringArray, MultiLineStringArray, MultiPointArray, MultiPolygonArray, PointArray,
-    PolygonArray, WKBArray,
+    PolygonArray, RectArray, WKBArray,
 };
 use crate::error::GeoArrowError;
 use crate::scalar::Geometry;
@@ -22,6 +22,7 @@ pub enum GeometryArray<O: Offset> {
     MultiLineString(MultiLineStringArray<O>),
     MultiPolygon(MultiPolygonArray<O>),
     WKB(WKBArray<O>),
+    Rect(RectArray),
 }
 
 impl<'a, O: Offset> GeometryArrayTrait<'a> for GeometryArray<O> {
@@ -39,6 +40,7 @@ impl<'a, O: Offset> GeometryArrayTrait<'a> for GeometryArray<O> {
             GeometryArray::MultiLineString(arr) => Geometry::MultiLineString(arr.value(i)),
             GeometryArray::MultiPolygon(arr) => Geometry::MultiPolygon(arr.value(i)),
             GeometryArray::WKB(arr) => Geometry::WKB(arr.value(i)),
+            GeometryArray::Rect(arr) => Geometry::Rect(arr.value(i)),
         }
     }
 
@@ -51,6 +53,7 @@ impl<'a, O: Offset> GeometryArrayTrait<'a> for GeometryArray<O> {
             GeometryArray::MultiLineString(arr) => arr.logical_type(),
             GeometryArray::MultiPolygon(arr) => arr.logical_type(),
             GeometryArray::WKB(arr) => arr.logical_type(),
+            GeometryArray::Rect(arr) => arr.logical_type(),
         }
     }
 
@@ -63,6 +66,7 @@ impl<'a, O: Offset> GeometryArrayTrait<'a> for GeometryArray<O> {
             GeometryArray::MultiLineString(arr) => arr.extension_type(),
             GeometryArray::MultiPolygon(arr) => arr.extension_type(),
             GeometryArray::WKB(arr) => arr.extension_type(),
+            GeometryArray::Rect(arr) => arr.extension_type(),
         }
     }
 
@@ -75,6 +79,7 @@ impl<'a, O: Offset> GeometryArrayTrait<'a> for GeometryArray<O> {
             GeometryArray::MultiLineString(arr) => arr.into_arrow().boxed(),
             GeometryArray::MultiPolygon(arr) => arr.into_arrow().boxed(),
             GeometryArray::WKB(arr) => arr.into_arrow().boxed(),
+            GeometryArray::Rect(arr) => arr.into_arrow().boxed(),
         }
     }
 
@@ -95,6 +100,7 @@ impl<'a, O: Offset> GeometryArrayTrait<'a> for GeometryArray<O> {
                 GeometryArray::MultiPolygon(arr.with_coords(coords))
             }
             GeometryArray::WKB(arr) => GeometryArray::WKB(arr.with_coords(coords)),
+            GeometryArray::Rect(arr) => GeometryArray::Rect(arr.with_coords(coords)),
         }
     }
 
@@ -107,6 +113,7 @@ impl<'a, O: Offset> GeometryArrayTrait<'a> for GeometryArray<O> {
             GeometryArray::MultiLineString(arr) => arr.coord_type(),
             GeometryArray::MultiPolygon(arr) => arr.coord_type(),
             GeometryArray::WKB(arr) => arr.coord_type(),
+            GeometryArray::Rect(arr) => arr.coord_type(),
         }
     }
 
@@ -127,6 +134,7 @@ impl<'a, O: Offset> GeometryArrayTrait<'a> for GeometryArray<O> {
                 GeometryArray::MultiPolygon(arr.into_coord_type(coord_type))
             }
             GeometryArray::WKB(arr) => GeometryArray::WKB(arr.into_coord_type(coord_type)),
+            GeometryArray::Rect(arr) => GeometryArray::Rect(arr.into_coord_type(coord_type)),
         }
     }
 
@@ -148,6 +156,7 @@ impl<'a, O: Offset> GeometryArrayTrait<'a> for GeometryArray<O> {
             GeometryArray::MultiLineString(arr) => arr.len(),
             GeometryArray::MultiPolygon(arr) => arr.len(),
             GeometryArray::WKB(arr) => arr.len(),
+            GeometryArray::Rect(arr) => arr.len(),
         }
     }
 
@@ -163,6 +172,7 @@ impl<'a, O: Offset> GeometryArrayTrait<'a> for GeometryArray<O> {
             GeometryArray::MultiLineString(arr) => arr.validity(),
             GeometryArray::MultiPolygon(arr) => arr.validity(),
             GeometryArray::WKB(arr) => arr.validity(),
+            GeometryArray::Rect(arr) => arr.validity(),
         }
     }
 
@@ -181,6 +191,7 @@ impl<'a, O: Offset> GeometryArrayTrait<'a> for GeometryArray<O> {
             GeometryArray::MultiLineString(arr) => arr.slice(offset, length),
             GeometryArray::MultiPolygon(arr) => arr.slice(offset, length),
             GeometryArray::WKB(arr) => arr.slice(offset, length),
+            GeometryArray::Rect(arr) => arr.slice(offset, length),
         }
     }
 
@@ -199,6 +210,7 @@ impl<'a, O: Offset> GeometryArrayTrait<'a> for GeometryArray<O> {
             GeometryArray::MultiLineString(arr) => arr.slice_unchecked(offset, length),
             GeometryArray::MultiPolygon(arr) => arr.slice_unchecked(offset, length),
             GeometryArray::WKB(arr) => arr.slice_unchecked(offset, length),
+            GeometryArray::Rect(arr) => arr.slice_unchecked(offset, length),
         }
     }
 
@@ -217,6 +229,7 @@ impl<'a, O: Offset> GeometryArrayTrait<'a> for GeometryArray<O> {
             GeometryArray::MultiLineString(arr) => GeometryArray::MultiLineString(arr.clone()),
             GeometryArray::MultiPolygon(arr) => GeometryArray::MultiPolygon(arr.clone()),
             GeometryArray::WKB(arr) => GeometryArray::WKB(arr.clone()),
+            GeometryArray::Rect(arr) => GeometryArray::Rect(arr.clone()),
         })
     }
 }
@@ -304,6 +317,7 @@ impl From<GeometryArray<i32>> for GeometryArray<i64> {
             GeometryArray::MultiLineString(arr) => GeometryArray::MultiLineString(arr.into()),
             GeometryArray::MultiPolygon(arr) => GeometryArray::MultiPolygon(arr.into()),
             GeometryArray::WKB(arr) => GeometryArray::WKB(arr.into()),
+            GeometryArray::Rect(arr) => GeometryArray::Rect(arr),
         }
     }
 }
@@ -320,6 +334,7 @@ impl TryFrom<GeometryArray<i64>> for GeometryArray<i32> {
             GeometryArray::MultiLineString(arr) => GeometryArray::MultiLineString(arr.try_into()?),
             GeometryArray::MultiPolygon(arr) => GeometryArray::MultiPolygon(arr.try_into()?),
             GeometryArray::WKB(arr) => GeometryArray::WKB(arr.try_into()?),
+            GeometryArray::Rect(arr) => GeometryArray::Rect(arr),
         })
     }
 }

--- a/src/array/geometry/rstar.rs
+++ b/src/array/geometry/rstar.rs
@@ -15,6 +15,7 @@ impl<O: Offset> RTreeObject for Geometry<'_, O> {
             Geometry::MultiLineString(geom) => geom.envelope(),
             Geometry::MultiPolygon(geom) => geom.envelope(),
             Geometry::WKB(geom) => geom.envelope(),
+            Geometry::Rect(geom) => geom.envelope(),
         }
     }
 }
@@ -29,6 +30,7 @@ impl<O: Offset> From<Geometry<'_, O>> for geo::Geometry {
             Geometry::MultiLineString(geom) => geom.into(),
             Geometry::MultiPolygon(geom) => geom.into(),
             Geometry::WKB(geom) => geom.into(),
+            Geometry::Rect(geom) => geom.into(),
         }
     }
 }

--- a/src/array/mod.rs
+++ b/src/array/mod.rs
@@ -12,6 +12,7 @@ pub use multipoint::{MultiPointArray, MutableMultiPointArray};
 pub use multipolygon::{MultiPolygonArray, MutableMultiPolygonArray};
 pub use point::{MutablePointArray, PointArray};
 pub use polygon::{MutablePolygonArray, PolygonArray};
+pub use rect::RectArray;
 
 pub mod binary;
 pub mod coord;
@@ -22,3 +23,4 @@ pub mod multipoint;
 pub mod multipolygon;
 pub mod point;
 pub mod polygon;
+pub mod rect;

--- a/src/array/rect/array.rs
+++ b/src/array/rect/array.rs
@@ -1,0 +1,140 @@
+use arrow2::array::{Array, FixedSizeListArray, PrimitiveArray};
+use arrow2::bitmap::Bitmap;
+use arrow2::buffer::Buffer;
+use arrow2::datatypes::{DataType, Field};
+use rstar::primitives::CachedEnvelope;
+use rstar::RTree;
+
+use crate::array::{CoordBuffer, CoordType};
+use crate::util::slice_validity_unchecked;
+use crate::GeometryArrayTrait;
+
+/// Internally this is implemented as a FixedSizeList[4], laid out as minx, miny, maxx, maxy.
+#[derive(Debug, Clone, PartialEq)]
+pub struct RectArray {
+    /// A Buffer of float values for the bounding rectangles
+    /// Invariant: the length of values must always be a multiple of 4
+    values: Buffer<f64>,
+    validity: Option<Bitmap>,
+}
+
+impl RectArray {
+    pub fn new(values: Buffer<f64>, validity: Option<Bitmap>) -> Self {
+        Self { values, validity }
+    }
+
+    fn inner_type(&self) -> DataType {
+        DataType::Float64
+    }
+
+    fn outer_type(&self) -> DataType {
+        let inner_field = Field::new("rect", self.inner_type(), false);
+        DataType::FixedSizeList(Box::new(inner_field), 4)
+    }
+}
+
+impl<'a> GeometryArrayTrait<'a> for RectArray {
+    type Scalar = crate::scalar::Rect<'a>;
+    type ScalarGeo = geo::Rect;
+    type ArrowArray = FixedSizeListArray;
+    type RTreeObject = CachedEnvelope<Self::Scalar>;
+
+    fn value(&'a self, i: usize) -> Self::Scalar {
+        crate::scalar::Rect {
+            values: &self.values,
+            geom_index: i,
+        }
+    }
+
+    fn logical_type(&self) -> DataType {
+        self.outer_type()
+    }
+
+    fn extension_type(&self) -> DataType {
+        DataType::Extension(
+            "geoarrow._rect".to_string(),
+            Box::new(self.logical_type()),
+            None,
+        )
+    }
+
+    fn into_arrow(self) -> Self::ArrowArray {
+        let extension_type = self.extension_type();
+        let validity = self.validity;
+
+        let values = PrimitiveArray::new(DataType::Float64, self.values, None);
+        FixedSizeListArray::new(extension_type, values.boxed(), validity)
+    }
+
+    fn into_boxed_arrow(self) -> Box<dyn Array> {
+        self.into_arrow().boxed()
+    }
+
+    fn with_coords(self, _coords: CoordBuffer) -> Self {
+        unimplemented!()
+    }
+
+    fn coord_type(&self) -> CoordType {
+        unimplemented!()
+    }
+
+    fn into_coord_type(self, _coord_type: CoordType) -> Self {
+        unimplemented!()
+    }
+
+    /// Build a spatial index containing this array's geometries
+    fn rstar_tree(&'a self) -> RTree<Self::RTreeObject> {
+        RTree::bulk_load(self.iter().flatten().map(CachedEnvelope::new).collect())
+    }
+
+    /// Returns the number of geometries in this array
+    #[inline]
+    fn len(&self) -> usize {
+        self.values.len() / 4
+    }
+
+    /// Returns the optional validity.
+    #[inline]
+    fn validity(&self) -> Option<&Bitmap> {
+        self.validity.as_ref()
+    }
+
+    /// Slices this [`PolygonArray`] in place.
+    /// # Implementation
+    /// This operation is `O(1)` as it amounts to increase two ref counts.
+    /// # Examples
+    /// ```
+    /// use arrow2::array::PrimitiveArray;
+    ///
+    /// let array = PrimitiveArray::from_vec(vec![1, 2, 3]);
+    /// assert_eq!(format!("{:?}", array), "Int32[1, 2, 3]");
+    /// let sliced = array.slice(1, 1);
+    /// assert_eq!(format!("{:?}", sliced), "Int32[2]");
+    /// // note: `sliced` and `array` share the same memory region.
+    /// ```
+    /// # Panic
+    /// This function panics iff `offset + length > self.len()`.
+    #[inline]
+    fn slice(&mut self, offset: usize, length: usize) {
+        assert!(
+            offset + length <= self.len(),
+            "offset + length may not exceed length of array"
+        );
+        unsafe { self.slice_unchecked(offset, length) }
+    }
+
+    /// Slices this [`PolygonArray`] in place.
+    /// # Implementation
+    /// This operation is `O(1)` as it amounts to increase two ref counts.
+    /// # Safety
+    /// The caller must ensure that `offset + length <= self.len()`.
+    #[inline]
+    unsafe fn slice_unchecked(&mut self, offset: usize, length: usize) {
+        slice_validity_unchecked(&mut self.validity, offset, length);
+        self.values.slice_unchecked(offset * 4, length * 4);
+    }
+
+    fn to_boxed(&self) -> Box<Self> {
+        Box::new(self.clone())
+    }
+}

--- a/src/array/rect/iterator.rs
+++ b/src/array/rect/iterator.rs
@@ -1,0 +1,152 @@
+use crate::array::RectArray;
+use crate::scalar::Rect;
+use crate::GeometryArrayTrait;
+use arrow2::bitmap::utils::{BitmapIter, ZipValidity};
+use arrow2::trusted_len::TrustedLen;
+
+/// Iterator of values of a [`RectArray`]
+#[derive(Clone, Debug)]
+pub struct RectArrayValuesIter<'a> {
+    array: &'a RectArray,
+    index: usize,
+    end: usize,
+}
+
+impl<'a> RectArrayValuesIter<'a> {
+    #[inline]
+    pub fn new(array: &'a RectArray) -> Self {
+        Self {
+            array,
+            index: 0,
+            end: array.len(),
+        }
+    }
+}
+
+impl<'a> Iterator for RectArrayValuesIter<'a> {
+    type Item = Rect<'a>;
+
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.index == self.end {
+            return None;
+        }
+        let old = self.index;
+        self.index += 1;
+        Some(self.array.value(old))
+    }
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        (self.end - self.index, Some(self.end - self.index))
+    }
+}
+
+unsafe impl<'a> TrustedLen for RectArrayValuesIter<'a> {}
+
+impl<'a> DoubleEndedIterator for RectArrayValuesIter<'a> {
+    #[inline]
+    fn next_back(&mut self) -> Option<Self::Item> {
+        if self.index == self.end {
+            None
+        } else {
+            self.end -= 1;
+            Some(self.array.value(self.end))
+        }
+    }
+}
+
+impl<'a> IntoIterator for &'a RectArray {
+    type Item = Option<Rect<'a>>;
+    type IntoIter = ZipValidity<Rect<'a>, RectArrayValuesIter<'a>, BitmapIter<'a>>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter()
+    }
+}
+
+impl<'a> RectArray {
+    /// Returns an iterator of `Option<Point>`
+    pub fn iter(&'a self) -> ZipValidity<Rect<'a>, RectArrayValuesIter<'a>, BitmapIter<'a>> {
+        ZipValidity::new_with_validity(RectArrayValuesIter::new(self), self.validity())
+    }
+
+    /// Returns an iterator of `Point`
+    pub fn values_iter(&'a self) -> RectArrayValuesIter<'a> {
+        RectArrayValuesIter::new(self)
+    }
+}
+
+// /// Iterator of values of a [`RectArray`]
+// #[derive(Clone, Debug)]
+// pub struct RectInteriorIterator<'a> {
+//     geom: &'a Rect<'a>,
+//     index: usize,
+//     end: usize,
+// }
+
+// impl<'a> RectInteriorIterator<'a> {
+//     #[inline]
+//     pub fn new(geom: &'a Rect<'a>) -> Self {
+//         Self {
+//             geom,
+//             index: 0,
+//             end: geom.num_interiors(),
+//         }
+//     }
+// }
+
+// impl<'a> Iterator for RectInteriorIterator<'a> {
+//     type Item = crate::scalar::LineString<'a>;
+
+//     #[inline]
+//     fn next(&mut self) -> Option<Self::Item> {
+//         if self.index == self.end {
+//             return None;
+//         }
+//         let old = self.index;
+//         self.index += 1;
+//         self.geom.interior(old)
+//     }
+
+//     #[inline]
+//     fn size_hint(&self) -> (usizeption<usize>) {
+//         (self.end - self.index, Some(self.end - self.index))
+//     }
+// }
+
+// impl<'a> ExactSizeIterator for RectInteriorIterator<'a> {
+//     // fn len(&self) -> usize {
+//     //     self.end
+//     // }
+// }
+
+// unsafe impl<'a> TrustedLen for RectInteriorIterator<'a> {}
+
+// impl<'a> DoubleEndedIterator for RectInteriorIterator<'a> {
+//     #[inline]
+//     fn next_back(&mut self) -> Option<Self::Item> {
+//         if self.index == self.end {
+//             None
+//         } else {
+//             self.end -= 1;
+//             self.geom.interior(self.end)
+//         }
+//     }
+// }
+
+// impl<'a> IntoIterator for &'a Rect<'a> {
+//     type Item = LineString<'a>;
+//     type IntoIter = RectInteriorIterator<'a>;
+
+//     fn into_iter(self) -> Self::IntoIter {
+//         self.iter()
+//     }
+// }
+
+// impl<'a> Rect<'a> {
+//     /// Returns an iterator of `Point`
+//     pub fn iter(&'a self) -> RectInteriorIterator<'a> {
+//         RectInteriorIterator::new(self)
+//     }
+// }

--- a/src/array/rect/mod.rs
+++ b/src/array/rect/mod.rs
@@ -1,0 +1,4 @@
+pub use array::RectArray;
+
+pub mod array;
+pub mod iterator;

--- a/src/geo_traits/geometry.rs
+++ b/src/geo_traits/geometry.rs
@@ -1,11 +1,11 @@
 use geo::{
     CoordNum, Geometry, GeometryCollection, LineString, MultiLineString, MultiPoint, MultiPolygon,
-    Point, Polygon,
+    Point, Polygon, Rect,
 };
 
 use super::{
     GeometryCollectionTrait, LineStringTrait, MultiLineStringTrait, MultiPointTrait,
-    MultiPolygonTrait, PointTrait, PolygonTrait,
+    MultiPolygonTrait, PointTrait, PolygonTrait, RectTrait,
 };
 
 #[allow(clippy::type_complexity)]
@@ -18,6 +18,7 @@ pub trait GeometryTrait<'a> {
     type MultiLineString: 'a + MultiLineStringTrait<'a, T = Self::T>;
     type MultiPolygon: 'a + MultiPolygonTrait<'a, T = Self::T>;
     type GeometryCollection: 'a + GeometryCollectionTrait<'a, T = Self::T>;
+    type Rect: 'a + RectTrait<'a, T = Self::T>;
 
     fn as_type(
         &'a self,
@@ -30,11 +31,12 @@ pub trait GeometryTrait<'a> {
         Self::MultiLineString,
         Self::MultiPolygon,
         Self::GeometryCollection,
+        Self::Rect,
     >;
 }
 
 #[derive(Debug)]
-pub enum GeometryType<'a, P, L, Y, MP, ML, MY, GC>
+pub enum GeometryType<'a, P, L, Y, MP, ML, MY, GC, R>
 where
     P: PointTrait,
     L: LineStringTrait<'a>,
@@ -43,6 +45,7 @@ where
     ML: MultiLineStringTrait<'a>,
     MY: MultiPolygonTrait<'a>,
     GC: GeometryCollectionTrait<'a>,
+    R: RectTrait<'a>,
 {
     Point(&'a P),
     LineString(&'a L),
@@ -51,6 +54,7 @@ where
     MultiLineString(&'a ML),
     MultiPolygon(&'a MY),
     GeometryCollection(&'a GC),
+    Rect(&'a R),
 }
 
 impl<'a, T: CoordNum + 'a> GeometryTrait<'a> for Geometry<T> {
@@ -62,6 +66,7 @@ impl<'a, T: CoordNum + 'a> GeometryTrait<'a> for Geometry<T> {
     type MultiLineString = MultiLineString<Self::T>;
     type MultiPolygon = MultiPolygon<Self::T>;
     type GeometryCollection = GeometryCollection<Self::T>;
+    type Rect = Rect<Self::T>;
 
     fn as_type(
         &'a self,
@@ -74,6 +79,7 @@ impl<'a, T: CoordNum + 'a> GeometryTrait<'a> for Geometry<T> {
         MultiLineString<T>,
         MultiPolygon<T>,
         GeometryCollection<T>,
+        Rect<T>,
     > {
         match self {
             Geometry::Point(p) => GeometryType::Point(p),
@@ -83,6 +89,7 @@ impl<'a, T: CoordNum + 'a> GeometryTrait<'a> for Geometry<T> {
             Geometry::MultiLineString(p) => GeometryType::MultiLineString(p),
             Geometry::MultiPolygon(p) => GeometryType::MultiPolygon(p),
             Geometry::GeometryCollection(p) => GeometryType::GeometryCollection(p),
+            Geometry::Rect(p) => GeometryType::Rect(p),
             _ => todo!(),
         }
     }

--- a/src/geo_traits/mod.rs
+++ b/src/geo_traits/mod.rs
@@ -14,6 +14,7 @@ pub use multi_point::MultiPointTrait;
 pub use multi_polygon::MultiPolygonTrait;
 pub use point::PointTrait;
 pub use polygon::PolygonTrait;
+pub use rect::RectTrait;
 
 mod coord;
 mod geometry;
@@ -24,3 +25,4 @@ mod multi_point;
 mod multi_polygon;
 mod point;
 mod polygon;
+mod rect;

--- a/src/geo_traits/rect.rs
+++ b/src/geo_traits/rect.rs
@@ -1,0 +1,38 @@
+use geo::{Coord, CoordNum, Rect};
+
+use crate::geo_traits::CoordTrait;
+
+pub trait RectTrait<'a> {
+    type T: CoordNum;
+    type ItemType: 'a + CoordTrait<T = Self::T>;
+
+    fn lower(&self) -> Self::ItemType;
+
+    fn upper(&self) -> Self::ItemType;
+}
+
+impl<'a, T: CoordNum + 'a> RectTrait<'a> for Rect<T> {
+    type T = T;
+    type ItemType = Coord<T>;
+
+    fn lower(&self) -> Self::ItemType {
+        self.min()
+    }
+
+    fn upper(&self) -> Self::ItemType {
+        self.max()
+    }
+}
+
+impl<'a, T: CoordNum + 'a> RectTrait<'a> for &Rect<T> {
+    type T = T;
+    type ItemType = Coord<T>;
+
+    fn lower(&self) -> Self::ItemType {
+        self.min()
+    }
+
+    fn upper(&self) -> Self::ItemType {
+        self.max()
+    }
+}

--- a/src/scalar/geometry/scalar.rs
+++ b/src/scalar/geometry/scalar.rs
@@ -9,4 +9,5 @@ pub enum Geometry<'a, O: Offset> {
     MultiLineString(crate::scalar::MultiLineString<'a, O>),
     MultiPolygon(crate::scalar::MultiPolygon<'a, O>),
     WKB(crate::scalar::WKB<'a, O>),
+    Rect(crate::scalar::Rect<'a>),
 }

--- a/src/scalar/mod.rs
+++ b/src/scalar/mod.rs
@@ -10,6 +10,7 @@ pub use multipoint::MultiPoint;
 pub use multipolygon::MultiPolygon;
 pub use point::Point;
 pub use polygon::Polygon;
+pub use rect::Rect;
 
 pub mod binary;
 pub mod coord;
@@ -20,3 +21,4 @@ pub mod multipoint;
 pub mod multipolygon;
 pub mod point;
 pub mod polygon;
+pub mod rect;

--- a/src/scalar/rect/mod.rs
+++ b/src/scalar/rect/mod.rs
@@ -1,0 +1,3 @@
+pub use scalar::Rect;
+
+pub mod scalar;

--- a/src/scalar/rect/scalar.rs
+++ b/src/scalar/rect/scalar.rs
@@ -1,6 +1,7 @@
 use arrow2::buffer::Buffer;
 use rstar::{RTreeObject, AABB};
 
+#[derive(Debug, Clone, PartialEq)]
 pub struct Rect<'a> {
     pub values: &'a Buffer<f64>,
     pub geom_index: usize,
@@ -25,6 +26,12 @@ impl From<Rect<'_>> for geo::Rect {
         let lower: geo::Coord = value.lower().into();
         let upper: geo::Coord = value.upper().into();
         geo::Rect::new(lower, upper)
+    }
+}
+
+impl From<Rect<'_>> for geo::Geometry {
+    fn from(value: Rect<'_>) -> Self {
+        geo::Geometry::Rect(value.into())
     }
 }
 

--- a/src/scalar/rect/scalar.rs
+++ b/src/scalar/rect/scalar.rs
@@ -1,0 +1,41 @@
+use arrow2::buffer::Buffer;
+use rstar::{RTreeObject, AABB};
+
+pub struct Rect<'a> {
+    pub values: &'a Buffer<f64>,
+    pub geom_index: usize,
+}
+
+impl<'a> Rect<'a> {
+    pub fn lower(&self) -> (f64, f64) {
+        let minx = self.values[self.geom_index * 4];
+        let miny = self.values[self.geom_index * 4 + 1];
+        (minx, miny)
+    }
+
+    pub fn upper(&self) -> (f64, f64) {
+        let maxx = self.values[self.geom_index * 4 + 2];
+        let maxy = self.values[self.geom_index * 4 + 3];
+        (maxx, maxy)
+    }
+}
+
+impl From<Rect<'_>> for geo::Rect {
+    fn from(value: Rect<'_>) -> Self {
+        let lower: geo::Coord = value.lower().into();
+        let upper: geo::Coord = value.upper().into();
+        geo::Rect::new(lower, upper)
+    }
+}
+
+impl RTreeObject for Rect<'_> {
+    type Envelope = AABB<[f64; 2]>;
+
+    fn envelope(&self) -> Self::Envelope {
+        let minx = self.values[self.geom_index * 4];
+        let miny = self.values[self.geom_index * 4 + 1];
+        let maxx = self.values[self.geom_index * 4 + 2];
+        let maxy = self.values[self.geom_index * 4 + 3];
+        AABB::from_corners([minx, miny], [maxx, maxy])
+    }
+}


### PR DESCRIPTION
Adds a `RectArray` (equivalent of an array of [`geo::Rect`](https://docs.rs/geo/latest/geo/geometry/struct.Rect.html)) to match `geo`. Also it means it will have efficient serialization of the output of `BoundingRect`, though its in-memory representation isn't defined by GeoArrow