### PR TITLE
start implementing algorithm traits on both arrays and scalars

### DIFF
--- a/js/src/algorithm/geo/affine_ops.rs
+++ b/js/src/algorithm/geo/affine_ops.rs
@@ -1,5 +1,6 @@
 use crate::array::*;
 use crate::broadcasting::BroadcastableAffine;
+use geoarrow::algorithm::broadcasting::BroadcastableVec;
 use wasm_bindgen::prelude::*;
 
 macro_rules! impl_rotate {
@@ -11,7 +12,14 @@ macro_rules! impl_rotate {
             #[wasm_bindgen(js_name = affineTransform)]
             pub fn affine_transform(&self, transform: BroadcastableAffine) -> Self {
                 use geoarrow::algorithm::geo::AffineOps;
-                AffineOps::affine_transform(&self.0, transform.0).into()
+                match transform.0 {
+                    BroadcastableVec::Array(arr) => {
+                        AffineOps::affine_transform(&self.0, &arr).into()
+                    }
+                    BroadcastableVec::Scalar(scalar) => {
+                        AffineOps::affine_transform(&self.0, &scalar).into()
+                    }
+                }
             }
         }
     };

--- a/js/src/algorithm/geo/rotate.rs
+++ b/js/src/algorithm/geo/rotate.rs
@@ -18,7 +18,7 @@ macro_rules! impl_rotate {
                         Rotate::rotate_around_centroid(&self.0, &arr).into()
                     }
                     BroadcastablePrimitive::Scalar(scalar) => {
-                        Rotate::rotate_around_centroid(&self.0, scalar).into()
+                        Rotate::rotate_around_centroid(&self.0, &scalar).into()
                     }
                 }
             }
@@ -34,7 +34,7 @@ macro_rules! impl_rotate {
                         Rotate::rotate_around_center(&self.0, &arr).into()
                     }
                     BroadcastablePrimitive::Scalar(scalar) => {
-                        Rotate::rotate_around_center(&self.0, scalar).into()
+                        Rotate::rotate_around_center(&self.0, &scalar).into()
                     }
                 }
             }

--- a/js/src/algorithm/geo/rotate.rs
+++ b/js/src/algorithm/geo/rotate.rs
@@ -1,5 +1,6 @@
 use crate::array::*;
 use crate::broadcasting::BroadcastableFloat;
+use geoarrow::algorithm::broadcasting::BroadcastablePrimitive;
 use wasm_bindgen::prelude::*;
 
 macro_rules! impl_rotate {
@@ -12,7 +13,14 @@ macro_rules! impl_rotate {
             #[wasm_bindgen(js_name = rotateAroundCentroid)]
             pub fn rotate_around_centroid(&self, degrees: BroadcastableFloat) -> Self {
                 use geoarrow::algorithm::geo::Rotate;
-                Rotate::rotate_around_centroid(&self.0, degrees.0).into()
+                match degrees.0 {
+                    BroadcastablePrimitive::Array(arr) => {
+                        Rotate::rotate_around_centroid(&self.0, &arr).into()
+                    }
+                    BroadcastablePrimitive::Scalar(scalar) => {
+                        Rotate::rotate_around_centroid(&self.0, scalar).into()
+                    }
+                }
             }
 
             /// Rotate a geometry around the center of its bounding box by an angle, in degrees.
@@ -21,7 +29,14 @@ macro_rules! impl_rotate {
             #[wasm_bindgen(js_name = rotateAroundCenter)]
             pub fn rotate_around_center(&self, degrees: BroadcastableFloat) -> Self {
                 use geoarrow::algorithm::geo::Rotate;
-                Rotate::rotate_around_center(&self.0, degrees.0).into()
+                match degrees.0 {
+                    BroadcastablePrimitive::Array(arr) => {
+                        Rotate::rotate_around_center(&self.0, &arr).into()
+                    }
+                    BroadcastablePrimitive::Scalar(scalar) => {
+                        Rotate::rotate_around_center(&self.0, scalar).into()
+                    }
+                }
             }
 
             // TODO: rotate around point

--- a/src/algorithm/geo/affine_ops.rs
+++ b/src/algorithm/geo/affine_ops.rs
@@ -1,4 +1,3 @@
-use crate::algorithm::broadcasting::BroadcastableVec;
 use crate::array::*;
 use arrow2::types::Offset;
 use geo::{AffineTransform, MapCoords};
@@ -36,10 +35,10 @@ use geo::{AffineTransform, MapCoords};
 ///     (x: -0.5688687, y: 5.5688687)
 /// ], max_relative = 1.0);
 /// ```
-pub trait AffineOps {
+pub trait AffineOps<Rhs> {
     /// Apply `transform` immutably, outputting a new geometry.
     #[must_use]
-    fn affine_transform(&self, transform: BroadcastableVec<AffineTransform>) -> Self;
+    fn affine_transform(&self, transform: &Rhs) -> Self;
 
     // TODO: add COW API for affine_transform_mut
     //
@@ -47,12 +46,73 @@ pub trait AffineOps {
     // fn affine_transform_mut(&mut self, transform: &AffineTransform<T>);
 }
 
+// ┌────────────────────────────────┐
+// │ Implementations for RHS arrays │
+// └────────────────────────────────┘
+
 // Note: this can't (easily) be parameterized in the macro because PointArray is not generic over O
-impl AffineOps for PointArray {
-    fn affine_transform(&self, transform: BroadcastableVec<AffineTransform>) -> Self {
+impl AffineOps<AffineTransform> for PointArray {
+    fn affine_transform(&self, transform: &AffineTransform) -> Self {
         let output_geoms: Vec<Option<geo::Point>> = self
             .iter_geo()
-            .zip(transform.into_iter())
+            .map(|maybe_g| maybe_g.map(|geom| geom.map_coords(|coord| transform.apply(coord))))
+            .collect();
+
+        output_geoms.into()
+    }
+}
+
+/// Implementation that iterates over geo objects
+macro_rules! iter_geo_impl {
+    ($type:ty, $geo_type:ty) => {
+        impl<O: Offset> AffineOps<AffineTransform> for $type {
+            fn affine_transform(&self, transform: &AffineTransform) -> Self {
+                let output_geoms: Vec<Option<$geo_type>> = self
+                    .iter_geo()
+                    .map(|maybe_g| {
+                        maybe_g.map(|geom| geom.map_coords(|coord| transform.apply(coord)))
+                    })
+                    .collect();
+
+                output_geoms.into()
+            }
+        }
+    };
+}
+
+iter_geo_impl!(LineStringArray<O>, geo::LineString);
+iter_geo_impl!(PolygonArray<O>, geo::Polygon);
+iter_geo_impl!(MultiLineStringArray<O>, geo::MultiLineString);
+iter_geo_impl!(MultiPolygonArray<O>, geo::MultiPolygon);
+iter_geo_impl!(WKBArray<O>, geo::Geometry);
+
+impl<O: Offset> AffineOps<AffineTransform> for MultiPointArray<O> {
+    fn affine_transform(&self, transform: &AffineTransform) -> Self {
+        let output_geoms: Vec<Option<geo::MultiPoint>> = self
+            .iter_geo()
+            .map(|maybe_g| maybe_g.map(|geom| geom.map_coords(|coord| transform.apply(coord))))
+            .collect();
+
+        output_geoms.into()
+    }
+}
+
+impl<O: Offset> AffineOps<AffineTransform> for GeometryArray<O> {
+    crate::geometry_array_delegate_impl! {
+        fn affine_transform(&self, transform: &AffineTransform) -> Self;
+    }
+}
+
+// ┌─────────────────────────────────┐
+// │ Implementations for RHS scalars │
+// └─────────────────────────────────┘
+
+// Note: this can't (easily) be parameterized in the macro because PointArray is not generic over O
+impl AffineOps<Vec<AffineTransform>> for PointArray {
+    fn affine_transform(&self, transform: &Vec<AffineTransform>) -> Self {
+        let output_geoms: Vec<Option<geo::Point>> = self
+            .iter_geo()
+            .zip(transform.iter())
             .map(|(maybe_g, transform)| {
                 maybe_g.map(|geom| geom.map_coords(|coord| transform.apply(coord)))
             })
@@ -65,11 +125,11 @@ impl AffineOps for PointArray {
 /// Implementation that iterates over geo objects
 macro_rules! iter_geo_impl {
     ($type:ty, $geo_type:ty) => {
-        impl<O: Offset> AffineOps for $type {
-            fn affine_transform(&self, transform: BroadcastableVec<AffineTransform>) -> Self {
+        impl<O: Offset> AffineOps<Vec<AffineTransform>> for $type {
+            fn affine_transform(&self, transform: &Vec<AffineTransform>) -> Self {
                 let output_geoms: Vec<Option<$geo_type>> = self
                     .iter_geo()
-                    .zip(transform.into_iter())
+                    .zip(transform.iter())
                     .map(|(maybe_g, transform)| {
                         maybe_g.map(|geom| geom.map_coords(|coord| transform.apply(coord)))
                     })
@@ -87,11 +147,11 @@ iter_geo_impl!(MultiLineStringArray<O>, geo::MultiLineString);
 iter_geo_impl!(MultiPolygonArray<O>, geo::MultiPolygon);
 iter_geo_impl!(WKBArray<O>, geo::Geometry);
 
-impl<O: Offset> AffineOps for MultiPointArray<O> {
-    fn affine_transform(&self, transform: BroadcastableVec<AffineTransform>) -> Self {
+impl<O: Offset> AffineOps<Vec<AffineTransform>> for MultiPointArray<O> {
+    fn affine_transform(&self, transform: &Vec<AffineTransform>) -> Self {
         let output_geoms: Vec<Option<geo::MultiPoint>> = self
             .iter_geo()
-            .zip(transform.into_iter())
+            .zip(transform.iter())
             .map(|(maybe_g, transform)| {
                 maybe_g.map(|geom| geom.map_coords(|coord| transform.apply(coord)))
             })
@@ -101,8 +161,8 @@ impl<O: Offset> AffineOps for MultiPointArray<O> {
     }
 }
 
-impl<O: Offset> AffineOps for GeometryArray<O> {
+impl<O: Offset> AffineOps<Vec<AffineTransform>> for GeometryArray<O> {
     crate::geometry_array_delegate_impl! {
-        fn affine_transform(&self, transform: BroadcastableVec<AffineTransform>) -> Self;
+        fn affine_transform(&self, transform: &Vec<AffineTransform>) -> Self;
     }
 }

--- a/src/algorithm/geo/rotate.rs
+++ b/src/algorithm/geo/rotate.rs
@@ -45,7 +45,7 @@ pub trait Rotate<DegreesT> {
     /// assert_relative_eq!(expected, rotated);
     /// ```
     #[must_use]
-    fn rotate_around_centroid(&self, degrees: DegreesT) -> Self;
+    fn rotate_around_centroid(&self, degrees: &DegreesT) -> Self;
 
     // /// Mutable version of [`Self::rotate_around_centroid`]
     // fn rotate_around_centroid_mut(&mut self, degrees: f64);
@@ -56,7 +56,7 @@ pub trait Rotate<DegreesT> {
     /// Positive angles are counter-clockwise, and negative angles are clockwise rotations.
     ///
     #[must_use]
-    fn rotate_around_center(&self, degrees: DegreesT) -> Self;
+    fn rotate_around_center(&self, degrees: &DegreesT) -> Self;
 
     // /// Mutable version of [`Self::rotate_around_center`]
     // fn rotate_around_center_mut(&mut self, degrees: f64);
@@ -89,7 +89,7 @@ pub trait Rotate<DegreesT> {
     /// ]);
     /// ```
     #[must_use]
-    fn rotate_around_point(&self, degrees: DegreesT, point: geo::Point) -> Self;
+    fn rotate_around_point(&self, degrees: &DegreesT, point: geo::Point) -> Self;
 
     // /// Mutable version of [`Self::rotate_around_point`]
     // fn rotate_around_point_mut(&mut self, degrees: f64, point: Point<f64>);
@@ -100,7 +100,7 @@ pub trait Rotate<DegreesT> {
 // └────────────────────────────────┘
 
 // Note: this can't (easily) be parameterized in the macro because PointArray is not generic over O
-impl Rotate<&PrimitiveArray<f64>> for PointArray {
+impl Rotate<PrimitiveArray<f64>> for PointArray {
     fn rotate_around_centroid(&self, degrees: &PrimitiveArray<f64>) -> Self {
         let centroids = self.centroid();
         let transforms: Vec<AffineTransform> = centroids
@@ -133,7 +133,7 @@ impl Rotate<&PrimitiveArray<f64>> for PointArray {
 /// Implementation that iterates over geo objects
 macro_rules! iter_geo_impl {
     ($type:ty) => {
-        impl<O: Offset> Rotate<&PrimitiveArray<f64>> for $type {
+        impl<O: Offset> Rotate<PrimitiveArray<f64>> for $type {
             fn rotate_around_centroid(&self, degrees: &PrimitiveArray<f64>) -> $type {
                 let centroids = self.centroid();
                 let transforms: Vec<AffineTransform> = centroids
@@ -176,7 +176,7 @@ iter_geo_impl!(MultiLineStringArray<O>);
 iter_geo_impl!(MultiPolygonArray<O>);
 iter_geo_impl!(WKBArray<O>);
 
-impl<O: Offset> Rotate<&PrimitiveArray<f64>> for GeometryArray<O> {
+impl<O: Offset> Rotate<PrimitiveArray<f64>> for GeometryArray<O> {
     crate::geometry_array_delegate_impl! {
         fn rotate_around_centroid(&self, degrees: &PrimitiveArray<f64>) -> Self;
         fn rotate_around_center(&self, degrees: &PrimitiveArray<f64>) -> Self;
@@ -190,32 +190,32 @@ impl<O: Offset> Rotate<&PrimitiveArray<f64>> for GeometryArray<O> {
 
 // Note: this can't (easily) be parameterized in the macro because PointArray is not generic over O
 impl Rotate<f64> for PointArray {
-    fn rotate_around_centroid(&self, degrees: f64) -> Self {
+    fn rotate_around_centroid(&self, degrees: &f64) -> Self {
         let centroids = self.centroid();
         let transforms: Vec<AffineTransform> = centroids
             .values_iter()
             .map(|point| {
                 let point: geo::Point = point.into();
-                AffineTransform::rotate(degrees, point)
+                AffineTransform::rotate(*degrees, point)
             })
             .collect();
         self.affine_transform(&transforms)
     }
 
-    fn rotate_around_center(&self, degrees: f64) -> Self {
+    fn rotate_around_center(&self, degrees: &f64) -> Self {
         let centers = self.center();
         let transforms: Vec<AffineTransform> = centers
             .values_iter()
             .map(|point| {
                 let point: geo::Point = point.into();
-                AffineTransform::rotate(degrees, point)
+                AffineTransform::rotate(*degrees, point)
             })
             .collect();
         self.affine_transform(&transforms)
     }
 
-    fn rotate_around_point(&self, degrees: f64, point: geo::Point) -> Self {
-        let transform = AffineTransform::rotate(degrees, point);
+    fn rotate_around_point(&self, degrees: &f64, point: geo::Point) -> Self {
+        let transform = AffineTransform::rotate(*degrees, point);
         self.affine_transform(&transform)
     }
 }
@@ -224,32 +224,32 @@ impl Rotate<f64> for PointArray {
 macro_rules! iter_geo_impl_scalar {
     ($type:ty) => {
         impl<O: Offset> Rotate<f64> for $type {
-            fn rotate_around_centroid(&self, degrees: f64) -> $type {
+            fn rotate_around_centroid(&self, degrees: &f64) -> $type {
                 let centroids = self.centroid();
                 let transforms: Vec<AffineTransform> = centroids
                     .values_iter()
                     .map(|point| {
                         let point: geo::Point = point.into();
-                        AffineTransform::rotate(degrees, point)
+                        AffineTransform::rotate(*degrees, point)
                     })
                     .collect();
                 self.affine_transform(&transforms)
             }
 
-            fn rotate_around_center(&self, degrees: f64) -> Self {
+            fn rotate_around_center(&self, degrees: &f64) -> Self {
                 let centers = self.center();
                 let transforms: Vec<AffineTransform> = centers
                     .values_iter()
                     .map(|point| {
                         let point: geo::Point = point.into();
-                        AffineTransform::rotate(degrees, point)
+                        AffineTransform::rotate(*degrees, point)
                     })
                     .collect();
                 self.affine_transform(&transforms)
             }
 
-            fn rotate_around_point(&self, degrees: f64, point: geo::Point) -> Self {
-                let transform = AffineTransform::rotate(degrees, point);
+            fn rotate_around_point(&self, degrees: &f64, point: geo::Point) -> Self {
+                let transform = AffineTransform::rotate(*degrees, point);
                 self.affine_transform(&transform)
             }
         }
@@ -265,8 +265,8 @@ iter_geo_impl_scalar!(WKBArray<O>);
 
 impl<O: Offset> Rotate<f64> for GeometryArray<O> {
     crate::geometry_array_delegate_impl! {
-        fn rotate_around_centroid(&self, degrees: f64) -> Self;
-        fn rotate_around_center(&self, degrees: f64) -> Self;
-        fn rotate_around_point(&self, degrees: f64, point: geo::Point) -> Self;
+        fn rotate_around_centroid(&self, degrees: &f64) -> Self;
+        fn rotate_around_center(&self, degrees: &f64) -> Self;
+        fn rotate_around_point(&self, degrees: &f64, point: geo::Point) -> Self;
     }
 }


### PR DESCRIPTION
For the _rust_ bindings, now that the wrappers are implemented in terms of traits, it allows us to do cool stuff like avoiding dealing with `Broadcastable...` and just calling them on array or scalar objects directly:

```rs
fn point_array() -> PointArray {
    todo!()
}
fn point<'a>() -> Point<'a> {
    todo!()
}
fn tmp() {
    let point_array = point_array();
    let point = point();
    let a = point_array.euclidean_distance(&point_array);
    let b = x.euclidean_distance(&point);
}
```

The other bindings will need to still have some sort of `Broadcastable` object