### PR TITLE
Update mutable array

### DIFF
--- a/src/algorithm/geo/center.rs
+++ b/src/algorithm/geo/center.rs
@@ -26,8 +26,8 @@ macro_rules! iter_geo_impl {
             fn center(&self) -> PointArray {
                 let mut output_array = MutablePointArray::with_capacity(self.len());
                 self.iter_geo().for_each(|maybe_g| {
-                    output_array.push_geo(
-                        maybe_g.and_then(|g| g.bounding_rect().map(|rect| rect.center().into())),
+                    output_array.push_point(
+                        maybe_g.and_then(|g| g.bounding_rect().map(|rect| rect.center())),
                     )
                 });
                 output_array.into()

--- a/src/algorithm/geo/centroid.rs
+++ b/src/algorithm/geo/centroid.rs
@@ -67,8 +67,9 @@ macro_rules! iter_geo_impl {
         impl<O: Offset> Centroid for $type {
             fn centroid(&self) -> PointArray {
                 let mut output_array = MutablePointArray::with_capacity(self.len());
-                self.iter_geo()
-                    .for_each(|maybe_g| output_array.push_geo(maybe_g.and_then(|g| g.centroid())));
+                self.iter_geo().for_each(|maybe_g| {
+                    output_array.push_point(maybe_g.and_then(|g| g.centroid()))
+                });
                 output_array.into()
             }
         }

--- a/src/array/coord/combined/mutable.rs
+++ b/src/array/coord/combined/mutable.rs
@@ -14,6 +14,14 @@ impl MutableCoordBuffer {
         }
     }
 
+    /// Returns the total number of coordinates the vector can hold without reallocating.
+    pub fn capacity(&self) -> usize {
+        match self {
+            MutableCoordBuffer::Interleaved(cb) => cb.capacity(),
+            MutableCoordBuffer::Separated(cb) => cb.capacity(),
+        }
+    }
+
     pub fn set_coord(&mut self, i: usize, coord: geo::Coord) {
         match self {
             MutableCoordBuffer::Interleaved(cb) => cb.set_coord(i, coord),
@@ -25,6 +33,20 @@ impl MutableCoordBuffer {
         match self {
             MutableCoordBuffer::Interleaved(cb) => cb.push_coord(coord),
             MutableCoordBuffer::Separated(cb) => cb.push_coord(coord),
+        }
+    }
+
+    pub fn set_xy(&mut self, i: usize, x: f64, y: f64) {
+        match self {
+            MutableCoordBuffer::Interleaved(cb) => cb.set_xy(i, x, y),
+            MutableCoordBuffer::Separated(cb) => cb.set_xy(i, x, y),
+        }
+    }
+
+    pub fn push_xy(&mut self, x: f64, y: f64) {
+        match self {
+            MutableCoordBuffer::Interleaved(cb) => cb.push_xy(x, y),
+            MutableCoordBuffer::Separated(cb) => cb.push_xy(x, y),
         }
     }
 

--- a/src/array/coord/interleaved/mutable.rs
+++ b/src/array/coord/interleaved/mutable.rs
@@ -24,6 +24,11 @@ impl MutableInterleavedCoordBuffer {
         }
     }
 
+    /// Returns the total number of coordinates the vector can hold without reallocating.
+    pub fn capacity(&self) -> usize {
+        self.coords.capacity() / 2
+    }
+
     pub fn set_coord(&mut self, i: usize, coord: geo::Coord) {
         self.coords[i * 2] = coord.x;
         self.coords[i * 2 + 1] = coord.y;
@@ -32,6 +37,11 @@ impl MutableInterleavedCoordBuffer {
     pub fn push_coord(&mut self, coord: impl CoordTrait<T = f64>) {
         self.coords.push(coord.x());
         self.coords.push(coord.y());
+    }
+
+    pub fn set_xy(&mut self, i: usize, x: f64, y: f64) {
+        self.coords[i * 2] = x;
+        self.coords[i * 2 + 1] = y;
     }
 
     pub fn push_xy(&mut self, x: f64, y: f64) {

--- a/src/array/coord/separated/mutable.rs
+++ b/src/array/coord/separated/mutable.rs
@@ -16,6 +16,13 @@ impl MutableSeparatedCoordBuffer {
         Self { x, y }
     }
 
+    pub fn with_capacity(capacity: usize) -> Self {
+        Self {
+            x: Vec::with_capacity(capacity),
+            y: Vec::with_capacity(capacity),
+        }
+    }
+
     /// Initialize a buffer of a given length with all coordinates set to 0.0
     pub fn initialize(len: usize) -> Self {
         Self {
@@ -24,21 +31,24 @@ impl MutableSeparatedCoordBuffer {
         }
     }
 
+    /// Returns the total number of coordinates the vector can hold without reallocating.
+    pub fn capacity(&self) -> usize {
+        self.x.capacity()
+    }
+
     pub fn set_coord(&mut self, i: usize, coord: geo::Coord) {
         self.x[i] = coord.x;
         self.y[i] = coord.y;
     }
 
-    pub fn with_capacity(capacity: usize) -> Self {
-        Self {
-            x: Vec::with_capacity(capacity),
-            y: Vec::with_capacity(capacity),
-        }
-    }
-
     pub fn push_coord(&mut self, coord: geo::Coord) {
         self.x.push(coord.x);
         self.y.push(coord.y);
+    }
+
+    pub fn set_xy(&mut self, i: usize, x: f64, y: f64) {
+        self.x[i] = x;
+        self.y[i] = y;
     }
 
     pub fn push_xy(&mut self, x: f64, y: f64) {

--- a/src/array/multilinestring/mutable.rs
+++ b/src/array/multilinestring/mutable.rs
@@ -86,6 +86,24 @@ impl<'a, O: Offset> MutableMultiLineStringArray<O> {
         arr.into_arrow()
     }
 
+    /// Add a new LineString to the end of this array.
+    ///
+    /// # Errors
+    ///
+    /// This function errors iff the new last item is larger than what O supports.
+    pub fn push_line_string(
+        &mut self,
+        _value: Option<impl LineStringTrait<'a, T = f64>>,
+    ) -> Result<(), GeoArrowError> {
+        // Push a single line string into this multi line string array
+        todo!()
+    }
+
+    /// Add a new MultiLineString to the end of this array.
+    ///
+    /// # Errors
+    ///
+    /// This function errors iff the new last item is larger than what O supports.
     pub fn push_multi_line_string(
         &mut self,
         value: Option<impl MultiLineStringTrait<'a, T = f64>>,

--- a/src/array/multilinestring/mutable.rs
+++ b/src/array/multilinestring/mutable.rs
@@ -3,7 +3,7 @@ use crate::array::{
     WKBArray,
 };
 use crate::error::GeoArrowError;
-use crate::geo_traits::{LineStringTrait, MultiLineStringTrait};
+use crate::geo_traits::{CoordTrait, LineStringTrait, MultiLineStringTrait};
 use crate::io::native::wkb::maybe_multi_line_string::WKBMaybeMultiLineString;
 use crate::scalar::WKB;
 use crate::GeometryArrayTrait;
@@ -33,7 +33,7 @@ pub type MultiLineStringInner<O> = (
     Option<MutableBitmap>,
 );
 
-impl<O: Offset> MutableMultiLineStringArray<O> {
+impl<'a, O: Offset> MutableMultiLineStringArray<O> {
     /// Creates a new empty [`MutableMultiLineStringArray`].
     pub fn new() -> Self {
         MutablePolygonArray::new().into()
@@ -42,10 +42,16 @@ impl<O: Offset> MutableMultiLineStringArray<O> {
     /// Creates a new [`MutableMultiLineStringArray`] with a capacity.
     pub fn with_capacities(
         coord_capacity: usize,
-        geom_capacity: usize,
         ring_capacity: usize,
+        geom_capacity: usize,
     ) -> Self {
-        MutablePolygonArray::with_capacities(coord_capacity, geom_capacity, ring_capacity).into()
+        let coords = MutableInterleavedCoordBuffer::with_capacity(coord_capacity);
+        Self {
+            coords: MutableCoordBuffer::Interleaved(coords),
+            geom_offsets: Offsets::<O>::with_capacity(geom_capacity),
+            ring_offsets: Offsets::<O>::with_capacity(ring_capacity),
+            validity: None,
+        }
     }
 
     /// The canonical method to create a [`MutableMultiLineStringArray`] out of its internal components.
@@ -79,6 +85,64 @@ impl<O: Offset> MutableMultiLineStringArray<O> {
         let arr: MultiLineStringArray<O> = self.into();
         arr.into_arrow()
     }
+
+    pub fn push_multi_line_string(
+        &mut self,
+        value: Option<impl MultiLineStringTrait<'a, T = f64>>,
+    ) -> Result<(), GeoArrowError> {
+        if let Some(multi_line_string) = value {
+            // Total number of linestrings in this multilinestring
+            let num_line_strings = multi_line_string.num_lines();
+            self.geom_offsets.try_push_usize(num_line_strings)?;
+
+            // For each ring:
+            // - Get ring
+            // - Add ring's # of coords to self.ring_offsets
+            // - Push ring's coords to self.coords
+
+            // Number of coords for each ring
+            for line_string_idx in 0..num_line_strings {
+                let line_string = multi_line_string.line(line_string_idx).unwrap();
+                self.ring_offsets
+                    .try_push_usize(line_string.num_coords())
+                    .unwrap();
+
+                for coord_idx in 0..line_string.num_coords() {
+                    let coord = line_string.coord(coord_idx).unwrap();
+                    self.coords.push_xy(coord.x(), coord.y());
+                }
+            }
+
+            // Set validity to true if validity buffer exists
+            if let Some(validity) = &mut self.validity {
+                validity.push(true)
+            }
+        } else {
+            self.push_null();
+        }
+        Ok(())
+    }
+
+    #[inline]
+    fn push_null(&mut self) {
+        // NOTE! Only the geom_offsets array needs to get extended, because the next geometry will
+        // point to the same ring array location
+        self.geom_offsets.extend_constant(1);
+        match &mut self.validity {
+            Some(validity) => validity.push(false),
+            None => self.init_validity(),
+        }
+    }
+
+    #[inline]
+    fn init_validity(&mut self) {
+        let len = self.geom_offsets.len_proxy();
+
+        let mut validity = MutableBitmap::with_capacity(self.geom_offsets.capacity());
+        validity.extend_constant(len, true);
+        validity.set(len - 1, false);
+        self.validity = Some(validity)
+    }
 }
 
 impl<O: Offset> Default for MutableMultiLineStringArray<O> {
@@ -105,95 +169,72 @@ impl<O: Offset> From<MutableMultiLineStringArray<O>> for MultiLineStringArray<O>
     }
 }
 
-fn first_pass<'a, O: Offset>(
+fn first_pass<'a>(
     geoms: impl Iterator<Item = Option<impl MultiLineStringTrait<'a> + 'a>>,
     geoms_length: usize,
-) -> (Offsets<O>, Offsets<O>, Option<MutableBitmap>) {
-    let mut validity = MutableBitmap::with_capacity(geoms_length);
+) -> (usize, usize, usize) {
+    // Total number of coordinates
+    let mut coord_capacity = 0;
+    let mut ring_capacity = 0;
+    let geom_capacity = geoms_length;
 
-    // Offset into ring indexes for each geometry
-    let mut geom_offsets = Offsets::<O>::with_capacity(geoms_length);
+    for multi_line_string in geoms.into_iter().flatten() {
+        // Total number of rings in this polygon
+        let num_line_strings = multi_line_string.num_lines();
+        ring_capacity += num_line_strings;
 
-    // Offset into coordinates for each ring
-    // This capacity will only be enough in the case where each geometry has only a single
-    // linestring
-    let mut ring_offsets = Offsets::<O>::with_capacity(geoms_length);
-
-    for maybe_multi_line_string in geoms {
-        if let Some(multi_line_string) = maybe_multi_line_string {
-            validity.push(true);
-
-            // Total number of linestrings in this multilinestring
-            let num_line_strings = multi_line_string.num_lines();
-            geom_offsets.try_push_usize(num_line_strings).unwrap();
-
-            // Number of coords for each ring
-            for line_string_idx in 0..num_line_strings {
-                let line_string = multi_line_string.line(line_string_idx).unwrap();
-                ring_offsets
-                    .try_push_usize(line_string.num_coords())
-                    .unwrap();
-            }
-        } else {
-            validity.push(false);
-            geom_offsets.try_push_usize(0).unwrap();
+        for line_string_idx in 0..num_line_strings {
+            let line_string = multi_line_string.line(line_string_idx).unwrap();
+            coord_capacity += line_string.num_coords();
         }
     }
 
-    let validity = if validity.unset_bits() == 0 {
-        None
-    } else {
-        Some(validity)
-    };
-
-    (geom_offsets, ring_offsets, validity)
+    // TODO: dataclass for capacities to access them by name?
+    (coord_capacity, ring_capacity, geom_capacity)
 }
 
 fn second_pass<'a, O: Offset>(
     geoms: impl Iterator<Item = Option<impl MultiLineStringTrait<'a, T = f64> + 'a>>,
-    geom_offsets: Offsets<O>,
-    ring_offsets: Offsets<O>,
-    validity: Option<MutableBitmap>,
+    coord_capacity: usize,
+    ring_capacity: usize,
+    geom_capacity: usize,
 ) -> MutableMultiLineStringArray<O> {
-    let mut coord_buffer =
-        MutableInterleavedCoordBuffer::with_capacity(ring_offsets.last().to_usize());
+    let mut array =
+        MutableMultiLineStringArray::with_capacities(coord_capacity, ring_capacity, geom_capacity);
 
-    for multi_line_string in geoms.into_iter().flatten() {
-        for line_string_idx in 0..multi_line_string.num_lines() {
-            let line_string = multi_line_string.line(line_string_idx).unwrap();
-            for coord_idx in 0..line_string.num_coords() {
-                let coord = line_string.coord(coord_idx).unwrap();
-                coord_buffer.push_coord(coord);
-            }
-        }
-    }
+    geoms
+        .into_iter()
+        .try_for_each(|maybe_multi_line_string| {
+            array.push_multi_line_string(maybe_multi_line_string)
+        })
+        .unwrap();
 
-    MutableMultiLineStringArray {
-        coords: MutableCoordBuffer::Interleaved(coord_buffer),
-        geom_offsets,
-        ring_offsets,
-        validity,
-    }
+    array
 }
 
 impl<O: Offset> From<Vec<geo::MultiLineString>> for MutableMultiLineStringArray<O> {
     fn from(geoms: Vec<geo::MultiLineString>) -> Self {
-        let (geom_offsets, ring_offsets, validity) =
-            first_pass::<O>(geoms.iter().map(Some), geoms.len());
+        let (coord_capacity, ring_capacity, geom_capacity) =
+            first_pass(geoms.iter().map(Some), geoms.len());
         second_pass(
             geoms.into_iter().map(Some),
-            geom_offsets,
-            ring_offsets,
-            validity,
+            coord_capacity,
+            ring_capacity,
+            geom_capacity,
         )
     }
 }
 
 impl<O: Offset> From<Vec<Option<geo::MultiLineString>>> for MutableMultiLineStringArray<O> {
     fn from(geoms: Vec<Option<geo::MultiLineString>>) -> Self {
-        let (geom_offsets, ring_offsets, validity) =
-            first_pass::<O>(geoms.iter().map(|x| x.as_ref()), geoms.len());
-        second_pass(geoms.into_iter(), geom_offsets, ring_offsets, validity)
+        let (coord_capacity, ring_capacity, geom_capacity) =
+            first_pass(geoms.iter().map(|x| x.as_ref()), geoms.len());
+        second_pass(
+            geoms.into_iter(),
+            coord_capacity,
+            ring_capacity,
+            geom_capacity,
+        )
     }
 }
 
@@ -201,13 +242,13 @@ impl<O: Offset> From<bumpalo::collections::Vec<'_, geo::MultiLineString>>
     for MutableMultiLineStringArray<O>
 {
     fn from(geoms: bumpalo::collections::Vec<'_, geo::MultiLineString>) -> Self {
-        let (geom_offsets, ring_offsets, validity) =
-            first_pass::<O>(geoms.iter().map(Some), geoms.len());
+        let (coord_capacity, ring_capacity, geom_capacity) =
+            first_pass(geoms.iter().map(Some), geoms.len());
         second_pass(
             geoms.into_iter().map(Some),
-            geom_offsets,
-            ring_offsets,
-            validity,
+            coord_capacity,
+            ring_capacity,
+            geom_capacity,
         )
     }
 }
@@ -216,9 +257,14 @@ impl<O: Offset> From<bumpalo::collections::Vec<'_, Option<geo::MultiLineString>>
     for MutableMultiLineStringArray<O>
 {
     fn from(geoms: bumpalo::collections::Vec<'_, Option<geo::MultiLineString>>) -> Self {
-        let (geom_offsets, ring_offsets, validity) =
-            first_pass::<O>(geoms.iter().map(|x| x.as_ref()), geoms.len());
-        second_pass(geoms.into_iter(), geom_offsets, ring_offsets, validity)
+        let (coord_capacity, ring_capacity, geom_capacity) =
+            first_pass(geoms.iter().map(|x| x.as_ref()), geoms.len());
+        second_pass(
+            geoms.into_iter(),
+            coord_capacity,
+            ring_capacity,
+            geom_capacity,
+        )
     }
 }
 
@@ -235,13 +281,13 @@ impl<O: Offset> TryFrom<WKBArray<O>> for MutableMultiLineStringArray<O> {
                     .map(|wkb| wkb.to_wkb_object().into_maybe_multi_line_string())
             })
             .collect();
-        let (geom_offsets, ring_offsets, validity) =
-            first_pass::<O>(wkb_objects2.iter().map(|item| item.as_ref()), value.len());
+        let (coord_capacity, ring_capacity, geom_capacity) =
+            first_pass(wkb_objects2.iter().map(|item| item.as_ref()), value.len());
         Ok(second_pass(
             wkb_objects2.iter().map(|item| item.as_ref()),
-            geom_offsets,
-            ring_offsets,
-            validity,
+            coord_capacity,
+            ring_capacity,
+            geom_capacity,
         ))
     }
 }

--- a/src/array/multipoint/mutable.rs
+++ b/src/array/multipoint/mutable.rs
@@ -119,11 +119,7 @@ impl<'a, O: Offset> MutableMultiPointArray<O> {
     #[inline]
     pub fn try_push_valid(&mut self) -> Result<()> {
         let length = self.calculate_added_length()?;
-        self.geom_offsets.try_push_usize(length)?;
-        if let Some(validity) = &mut self.validity {
-            validity.push(true)
-        }
-        Ok(())
+        self.try_push_length(length)
     }
 
     /// Needs to be called when a valid value was extended to this array.

--- a/src/array/multipolygon/mutable.rs
+++ b/src/array/multipolygon/mutable.rs
@@ -101,6 +101,23 @@ impl<'a, O: Offset> MutableMultiPolygonArray<O> {
         arr.into_arrow()
     }
 
+    /// Add a new Polygon to the end of this array.
+    ///
+    /// # Errors
+    ///
+    /// This function errors iff the new last item is larger than what O supports.
+    pub fn push_polygon(
+        &mut self,
+        _value: Option<impl PolygonTrait<'a, T = f64>>,
+    ) -> Result<(), GeoArrowError> {
+        todo!()
+    }
+
+    /// Add a new MultiPolygon to the end of this array.
+    ///
+    /// # Errors
+    ///
+    /// This function errors iff the new last item is larger than what O supports.
     pub fn push_multi_polygon(
         &mut self,
         value: Option<impl MultiPolygonTrait<'a, T = f64>>,

--- a/src/array/multipolygon/mutable.rs
+++ b/src/array/multipolygon/mutable.rs
@@ -2,7 +2,7 @@ use crate::array::{
     MultiPolygonArray, MutableCoordBuffer, MutableInterleavedCoordBuffer, WKBArray,
 };
 use crate::error::GeoArrowError;
-use crate::geo_traits::{LineStringTrait, MultiPolygonTrait, PolygonTrait};
+use crate::geo_traits::{CoordTrait, LineStringTrait, MultiPolygonTrait, PolygonTrait};
 use crate::io::native::wkb::maybe_multipolygon::WKBMaybeMultiPolygon;
 use crate::scalar::WKB;
 use crate::GeometryArrayTrait;
@@ -25,7 +25,7 @@ pub type MutableMultiPolygonParts<O> = (
 pub struct MutableMultiPolygonArray<O: Offset> {
     coords: MutableCoordBuffer,
 
-    /// Offsets into the ring array where each geometry starts
+    /// Offsets into the polygon array where each geometry starts
     geom_offsets: Offsets<O>,
 
     /// Offsets into the ring array where each polygon starts
@@ -38,7 +38,7 @@ pub struct MutableMultiPolygonArray<O: Offset> {
     validity: Option<MutableBitmap>,
 }
 
-impl<O: Offset> MutableMultiPolygonArray<O> {
+impl<'a, O: Offset> MutableMultiPolygonArray<O> {
     /// Creates a new empty [`MutableMultiPolygonArray`].
     pub fn new() -> Self {
         Self::with_capacities(0, 0, 0, 0)
@@ -47,9 +47,9 @@ impl<O: Offset> MutableMultiPolygonArray<O> {
     /// Creates a new [`MutableMultiPolygonArray`] with a capacity.
     pub fn with_capacities(
         coord_capacity: usize,
-        geom_capacity: usize,
-        polygon_capacity: usize,
         ring_capacity: usize,
+        polygon_capacity: usize,
+        geom_capacity: usize,
     ) -> Self {
         let coords = MutableInterleavedCoordBuffer::with_capacity(coord_capacity);
         Self {
@@ -100,6 +100,74 @@ impl<O: Offset> MutableMultiPolygonArray<O> {
         let arr: MultiPolygonArray<O> = self.into();
         arr.into_arrow()
     }
+
+    pub fn push_multi_polygon(
+        &mut self,
+        value: Option<impl MultiPolygonTrait<'a, T = f64>>,
+    ) -> Result<(), GeoArrowError> {
+        if let Some(multi_polygon) = value {
+            // Total number of polygons in this MultiPolygon
+            let num_polygons = multi_polygon.num_polygons();
+            self.geom_offsets.try_push_usize(num_polygons).unwrap();
+
+            // Iterate over polygons
+            for polygon_idx in 0..num_polygons {
+                let polygon = multi_polygon.polygon(polygon_idx).unwrap();
+
+                let ext_ring = polygon.exterior();
+                for coord_idx in 0..ext_ring.num_coords() {
+                    let coord = ext_ring.coord(coord_idx).unwrap();
+                    self.coords.push_xy(coord.x(), coord.y());
+                }
+
+                // Total number of rings in this Multipolygon
+                self.polygon_offsets
+                    .try_push_usize(polygon.num_interiors() + 1)
+                    .unwrap();
+
+                // Number of coords for each ring
+                self.ring_offsets
+                    .try_push_usize(polygon.exterior().num_coords())
+                    .unwrap();
+
+                for int_ring_idx in 0..polygon.num_interiors() {
+                    let int_ring = polygon.interior(int_ring_idx).unwrap();
+                    self.ring_offsets
+                        .try_push_usize(int_ring.num_coords())
+                        .unwrap();
+
+                    for coord_idx in 0..int_ring.num_coords() {
+                        let coord = int_ring.coord(coord_idx).unwrap();
+                        self.coords.push_xy(coord.x(), coord.y());
+                    }
+                }
+            }
+        } else {
+            self.push_null();
+        };
+        Ok(())
+    }
+
+    #[inline]
+    fn push_null(&mut self) {
+        // NOTE! Only the geom_offsets array needs to get extended, because the next geometry will
+        // point to the same polygon array location
+        self.geom_offsets.extend_constant(1);
+        match &mut self.validity {
+            Some(validity) => validity.push(false),
+            None => self.init_validity(),
+        }
+    }
+
+    #[inline]
+    fn init_validity(&mut self) {
+        let len = self.geom_offsets.len_proxy();
+
+        let mut validity = MutableBitmap::with_capacity(self.geom_offsets.capacity());
+        validity.extend_constant(len, true);
+        validity.set(len - 1, false);
+        self.validity = Some(validity)
+    }
 }
 
 impl<O: Offset> Default for MutableMultiPolygonArray<O> {
@@ -133,129 +201,90 @@ impl<O: Offset> From<MutableMultiPolygonArray<O>> for MultiPolygonArray<O> {
     }
 }
 
-fn first_pass<'a, O: Offset>(
+fn first_pass<'a>(
     geoms: impl Iterator<Item = Option<impl MultiPolygonTrait<'a> + 'a>>,
     geoms_length: usize,
-) -> (Offsets<O>, Offsets<O>, Offsets<O>, Option<MutableBitmap>) {
-    let mut validity = MutableBitmap::with_capacity(geoms_length);
+) -> (usize, usize, usize, usize) {
+    let mut coord_capacity = 0;
+    let mut ring_capacity = 0;
+    let mut polygon_capacity = 0;
+    let geom_capacity = geoms_length;
 
-    // Offset into polygon indexes for each geometry
-    let mut geom_offsets = Offsets::<O>::with_capacity(geoms_length);
+    for multi_polygon in geoms.into_iter().flatten() {
+        // Total number of polygons in this MultiPolygon
+        let num_polygons = multi_polygon.num_polygons();
+        polygon_capacity += num_polygons;
 
-    // Offset into rings for each polygon
-    // This capacity will only be enough in the case where each geometry has only a single
-    // polygon
-    let mut polygon_offsets = Offsets::<O>::with_capacity(geoms_length);
+        for polygon_idx in 0..num_polygons {
+            let polygon = multi_polygon.polygon(polygon_idx).unwrap();
 
-    // Offset into coordinates for each ring
-    // This capacity will only be enough in the case where each polygon has only a single ring
-    let mut ring_offsets = Offsets::<O>::with_capacity(geoms_length);
+            // Total number of rings in this MultiPolygon
+            ring_capacity += polygon.num_interiors() + 1;
 
-    for maybe_multipolygon in geoms {
-        if let Some(multipolygon) = maybe_multipolygon {
-            validity.push(true);
+            // Number of coords for each ring
+            coord_capacity += polygon.exterior().num_coords();
 
-            // Total number of polygons in this MultiPolygon
-            let num_polygons = multipolygon.num_polygons();
-            geom_offsets.try_push_usize(num_polygons).unwrap();
-
-            for polygon_idx in 0..num_polygons {
-                let polygon = multipolygon.polygon(polygon_idx).unwrap();
-
-                // Total number of rings in this Multipolygon
-                polygon_offsets
-                    .try_push_usize(polygon.num_interiors() + 1)
-                    .unwrap();
-
-                // Number of coords for each ring
-                ring_offsets
-                    .try_push_usize(polygon.exterior().num_coords())
-                    .unwrap();
-
-                for int_ring_idx in 0..polygon.num_interiors() {
-                    let int_ring = polygon.interior(int_ring_idx).unwrap();
-                    ring_offsets.try_push_usize(int_ring.num_coords()).unwrap();
-                }
+            for int_ring_idx in 0..polygon.num_interiors() {
+                let int_ring = polygon.interior(int_ring_idx).unwrap();
+                coord_capacity += int_ring.num_coords();
             }
-        } else {
-            validity.push(false);
-            geom_offsets.try_push_usize(0).unwrap();
         }
     }
 
-    let validity = if validity.unset_bits() == 0 {
-        None
-    } else {
-        Some(validity)
-    };
-
-    (geom_offsets, polygon_offsets, ring_offsets, validity)
+    (
+        coord_capacity,
+        ring_capacity,
+        polygon_capacity,
+        geom_capacity,
+    )
 }
 
 fn second_pass<'a, O: Offset>(
     geoms: impl Iterator<Item = Option<impl MultiPolygonTrait<'a, T = f64> + 'a>>,
-    geom_offsets: Offsets<O>,
-    polygon_offsets: Offsets<O>,
-    ring_offsets: Offsets<O>,
-    validity: Option<MutableBitmap>,
+    coord_capacity: usize,
+    ring_capacity: usize,
+    polygon_capacity: usize,
+    geom_capacity: usize,
 ) -> MutableMultiPolygonArray<O> {
-    let mut coord_buffer =
-        MutableInterleavedCoordBuffer::with_capacity(geom_offsets.last().to_usize());
+    let mut array = MutableMultiPolygonArray::with_capacities(
+        coord_capacity,
+        ring_capacity,
+        polygon_capacity,
+        geom_capacity,
+    );
 
-    for multipolygon in geoms.into_iter().flatten() {
-        let num_polygons = multipolygon.num_polygons();
-        for polygon_idx in 0..num_polygons {
-            let polygon = multipolygon.polygon(polygon_idx).unwrap();
+    geoms
+        .into_iter()
+        .try_for_each(|maybe_multi_polygon| array.push_multi_polygon(maybe_multi_polygon))
+        .unwrap();
 
-            let ext_ring = polygon.exterior();
-            for coord_idx in 0..ext_ring.num_coords() {
-                let coord = ext_ring.coord(coord_idx).unwrap();
-                coord_buffer.push_coord(coord);
-            }
-
-            for int_ring_idx in 0..polygon.num_interiors() {
-                let int_ring = polygon.interior(int_ring_idx).unwrap();
-                for coord_idx in 0..int_ring.num_coords() {
-                    let coord = int_ring.coord(coord_idx).unwrap();
-                    coord_buffer.push_coord(coord);
-                }
-            }
-        }
-    }
-
-    MutableMultiPolygonArray {
-        coords: MutableCoordBuffer::Interleaved(coord_buffer),
-        geom_offsets,
-        polygon_offsets,
-        ring_offsets,
-        validity,
-    }
+    array
 }
 
 impl<O: Offset> From<Vec<geo::MultiPolygon>> for MutableMultiPolygonArray<O> {
     fn from(geoms: Vec<geo::MultiPolygon>) -> Self {
-        let (geom_offsets, polygon_offsets, ring_offsets, validity) =
-            first_pass::<O>(geoms.iter().map(Some), geoms.len());
+        let (coord_capacity, ring_capacity, polygon_capacity, geom_capacity) =
+            first_pass(geoms.iter().map(Some), geoms.len());
         second_pass(
             geoms.into_iter().map(Some),
-            geom_offsets,
-            polygon_offsets,
-            ring_offsets,
-            validity,
+            coord_capacity,
+            ring_capacity,
+            polygon_capacity,
+            geom_capacity,
         )
     }
 }
 
 impl<O: Offset> From<Vec<Option<geo::MultiPolygon>>> for MutableMultiPolygonArray<O> {
     fn from(geoms: Vec<Option<geo::MultiPolygon>>) -> Self {
-        let (geom_offsets, polygon_offsets, ring_offsets, validity) =
-            first_pass::<O>(geoms.iter().map(|x| x.as_ref()), geoms.len());
+        let (coord_capacity, ring_capacity, polygon_capacity, geom_capacity) =
+            first_pass(geoms.iter().map(|x| x.as_ref()), geoms.len());
         second_pass(
             geoms.into_iter(),
-            geom_offsets,
-            polygon_offsets,
-            ring_offsets,
-            validity,
+            coord_capacity,
+            ring_capacity,
+            polygon_capacity,
+            geom_capacity,
         )
     }
 }
@@ -264,14 +293,14 @@ impl<O: Offset> From<bumpalo::collections::Vec<'_, geo::MultiPolygon>>
     for MutableMultiPolygonArray<O>
 {
     fn from(geoms: bumpalo::collections::Vec<'_, geo::MultiPolygon>) -> Self {
-        let (geom_offsets, polygon_offsets, ring_offsets, validity) =
-            first_pass::<O>(geoms.iter().map(Some), geoms.len());
+        let (coord_capacity, ring_capacity, polygon_capacity, geom_capacity) =
+            first_pass(geoms.iter().map(Some), geoms.len());
         second_pass(
             geoms.into_iter().map(Some),
-            geom_offsets,
-            polygon_offsets,
-            ring_offsets,
-            validity,
+            coord_capacity,
+            ring_capacity,
+            polygon_capacity,
+            geom_capacity,
         )
     }
 }
@@ -280,14 +309,14 @@ impl<O: Offset> From<bumpalo::collections::Vec<'_, Option<geo::MultiPolygon>>>
     for MutableMultiPolygonArray<O>
 {
     fn from(geoms: bumpalo::collections::Vec<'_, Option<geo::MultiPolygon>>) -> Self {
-        let (geom_offsets, polygon_offsets, ring_offsets, validity) =
-            first_pass::<O>(geoms.iter().map(|x| x.as_ref()), geoms.len());
+        let (coord_capacity, ring_capacity, polygon_capacity, geom_capacity) =
+            first_pass(geoms.iter().map(|x| x.as_ref()), geoms.len());
         second_pass(
             geoms.into_iter(),
-            geom_offsets,
-            polygon_offsets,
-            ring_offsets,
-            validity,
+            coord_capacity,
+            ring_capacity,
+            polygon_capacity,
+            geom_capacity,
         )
     }
 }
@@ -305,14 +334,14 @@ impl<O: Offset> TryFrom<WKBArray<O>> for MutableMultiPolygonArray<O> {
                     .map(|wkb| wkb.to_wkb_object().into_maybe_multi_polygon())
             })
             .collect();
-        let (geom_offsets, polygon_offsets, ring_offsets, validity) =
-            first_pass::<O>(wkb_objects2.iter().map(|item| item.as_ref()), value.len());
+        let (coord_capacity, ring_capacity, polygon_capacity, geom_capacity) =
+            first_pass(wkb_objects2.iter().map(|item| item.as_ref()), value.len());
         Ok(second_pass(
             wkb_objects2.iter().map(|item| item.as_ref()),
-            geom_offsets,
-            polygon_offsets,
-            ring_offsets,
-            validity,
+            coord_capacity,
+            ring_capacity,
+            polygon_capacity,
+            geom_capacity,
         ))
     }
 }

--- a/src/array/polygon/mutable.rs
+++ b/src/array/polygon/mutable.rs
@@ -93,6 +93,11 @@ impl<'a, O: Offset> MutablePolygonArray<O> {
         polygon_array.into_arrow()
     }
 
+    /// Add a new Polygon to the end of this array.
+    ///
+    /// # Errors
+    ///
+    /// This function errors iff the new last item is larger than what O supports.
     pub fn push_polygon(&mut self, value: Option<impl PolygonTrait<'a, T = f64>>) -> Result<()> {
         if let Some(polygon) = value {
             // - Get exterior ring


### PR DESCRIPTION
### Change list 

- Add `push_point`, `push_line_string`, etc, methods on the mutable arrays that take as input an `Option` of something that implements a geometry access trait
- Refactor `first_pass` to only compute _capacities_. This is strictly improved from what we have now, because we don't know exactly how many ring offsets to allocate before looping through the array once.
- Refactor `second_pass` to use the `push_*` methods, for simplicity and DRY
- Add `capacity` method to coord buffer structs to get the currently reserved capacity