### PR TITLE
Fixed `PartialEq` for CoordBuffer and Scalars

### DIFF
--- a/src/array/coord/interleaved/array.rs
+++ b/src/array/coord/interleaved/array.rs
@@ -108,7 +108,7 @@ impl<'a> GeometryArrayTrait<'a> for InterleavedCoordBuffer {
 
     fn slice(&mut self, offset: usize, length: usize) {
         assert!(
-            (offset * 2) + (length * 2) <= self.len(),
+            offset + length <= self.len(),
             "offset + length may not exceed length of array"
         );
         unsafe { self.slice_unchecked(offset, length) };
@@ -148,5 +148,30 @@ impl TryFrom<&FixedSizeListArray> for InterleavedCoordBuffer {
         Ok(InterleavedCoordBuffer::new(
             coord_array_values.values().clone(),
         ))
+    }
+}
+
+impl TryFrom<Vec<f64>> for InterleavedCoordBuffer {
+    type Error = GeoArrowError;
+
+    fn try_from(value: Vec<f64>) -> std::result::Result<Self, Self::Error> {
+        Self::try_new(value.into())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_eq_slicing() {
+        let coords1 = vec![0., 3., 1., 4., 2., 5.];
+        let mut buf1 = InterleavedCoordBuffer::new(coords1.into());
+        buf1.slice(1, 1);
+
+        let coords2 = vec![1., 4.];
+        let buf2 = InterleavedCoordBuffer::new(coords2.into());
+
+        assert_eq!(buf1, buf2);
     }
 }

--- a/src/array/coord/separated/array.rs
+++ b/src/array/coord/separated/array.rs
@@ -165,3 +165,33 @@ impl TryFrom<&StructArray> for SeparatedCoordBuffer {
         ))
     }
 }
+
+impl TryFrom<(Vec<f64>, Vec<f64>)> for SeparatedCoordBuffer {
+    type Error = GeoArrowError;
+
+    fn try_from(value: (Vec<f64>, Vec<f64>)) -> std::result::Result<Self, Self::Error> {
+        Self::try_new(value.0.into(), value.1.into())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_eq_slicing() {
+        let x1 = vec![0., 1., 2.];
+        let y1 = vec![3., 4., 5.];
+
+        let mut buf1 = SeparatedCoordBuffer::new(x1.into(), y1.into());
+        buf1.slice(1, 1);
+        dbg!(&buf1.x);
+        dbg!(&buf1.y);
+
+        let x2 = vec![1.];
+        let y2 = vec![4.];
+        let buf2 = SeparatedCoordBuffer::new(x2.into(), y2.into());
+
+        assert_eq!(buf1, buf2);
+    }
+}

--- a/src/scalar/binary/scalar.rs
+++ b/src/scalar/binary/scalar.rs
@@ -7,7 +7,7 @@ use geozero::ToGeo;
 use rstar::{RTreeObject, AABB};
 
 /// An Arrow equivalent of a Point
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone)]
 pub struct WKB<'a, O: Offset> {
     pub arr: &'a BinaryArray<O>,
     pub geom_index: usize,
@@ -59,5 +59,11 @@ impl<O: Offset> RTreeObject for WKB<'_, O> {
         let lower: [f64; 2] = rect.min().into();
         let upper: [f64; 2] = rect.max().into();
         AABB::from_corners(lower, upper)
+    }
+}
+
+impl<O: Offset> PartialEq for WKB<'_, O> {
+    fn eq(&self, other: &Self) -> bool {
+        self.arr.value(self.geom_index) == other.arr.value(other.geom_index)
     }
 }

--- a/src/scalar/coord/combined/scalar.rs
+++ b/src/scalar/coord/combined/scalar.rs
@@ -1,5 +1,6 @@
 use rstar::{RTreeObject, AABB};
 
+use crate::geo_traits::CoordTrait;
 use crate::scalar::{InterleavedCoord, SeparatedCoord};
 use crate::trait_::GeometryScalarTrait;
 
@@ -54,6 +55,42 @@ impl RTreeObject for Coord<'_> {
         match self {
             Coord::Interleaved(c) => c.envelope(),
             Coord::Separated(c) => c.envelope(),
+        }
+    }
+}
+
+impl CoordTrait for Coord<'_> {
+    type T = f64;
+
+    fn x(&self) -> Self::T {
+        match self {
+            Coord::Interleaved(c) => c.x(),
+            Coord::Separated(c) => c.x(),
+        }
+    }
+
+    fn y(&self) -> Self::T {
+        match self {
+            Coord::Interleaved(c) => c.y(),
+            Coord::Separated(c) => c.y(),
+        }
+    }
+}
+
+impl CoordTrait for &Coord<'_> {
+    type T = f64;
+
+    fn x(&self) -> Self::T {
+        match self {
+            Coord::Interleaved(c) => c.x(),
+            Coord::Separated(c) => c.x(),
+        }
+    }
+
+    fn y(&self) -> Self::T {
+        match self {
+            Coord::Interleaved(c) => c.y(),
+            Coord::Separated(c) => c.y(),
         }
     }
 }

--- a/src/scalar/coord/combined/scalar.rs
+++ b/src/scalar/coord/combined/scalar.rs
@@ -4,7 +4,7 @@ use crate::geo_traits::CoordTrait;
 use crate::scalar::{InterleavedCoord, SeparatedCoord};
 use crate::trait_::GeometryScalarTrait;
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone)]
 pub enum Coord<'a> {
     Separated(SeparatedCoord<'a>),
     Interleaved(InterleavedCoord<'a>),
@@ -56,6 +56,24 @@ impl RTreeObject for Coord<'_> {
             Coord::Interleaved(c) => c.envelope(),
             Coord::Separated(c) => c.envelope(),
         }
+    }
+}
+
+impl PartialEq for Coord<'_> {
+    fn eq(&self, other: &Self) -> bool {
+        self.x_y() == other.x_y()
+    }
+}
+
+impl PartialEq<InterleavedCoord<'_>> for Coord<'_> {
+    fn eq(&self, other: &InterleavedCoord<'_>) -> bool {
+        self.x_y() == other.x_y()
+    }
+}
+
+impl PartialEq<SeparatedCoord<'_>> for Coord<'_> {
+    fn eq(&self, other: &SeparatedCoord<'_>) -> bool {
+        self.x_y() == other.x_y()
     }
 }
 

--- a/src/scalar/coord/interleaved/scalar.rs
+++ b/src/scalar/coord/interleaved/scalar.rs
@@ -5,7 +5,7 @@ use crate::geo_traits::CoordTrait;
 use crate::scalar::SeparatedCoord;
 use crate::trait_::GeometryScalarTrait;
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone)]
 pub struct InterleavedCoord<'a> {
     pub coords: &'a Buffer<f64>,
     pub i: usize,
@@ -55,6 +55,12 @@ impl RTreeObject for InterleavedCoord<'_> {
     }
 }
 
+impl PartialEq for InterleavedCoord<'_> {
+    fn eq(&self, other: &Self) -> bool {
+        self.x_y() == other.x_y()
+    }
+}
+
 impl PartialEq<SeparatedCoord<'_>> for InterleavedCoord<'_> {
     fn eq(&self, other: &SeparatedCoord<'_>) -> bool {
         self.x_y() == other.x_y()
@@ -82,5 +88,39 @@ impl CoordTrait for &InterleavedCoord<'_> {
 
     fn y(&self) -> Self::T {
         *self.coords.get(self.i * 2 + 1).unwrap()
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::array::{InterleavedCoordBuffer, SeparatedCoordBuffer};
+    use crate::GeometryArrayTrait;
+
+    /// Test Eq where the current index is true but another index is false
+    #[test]
+    fn test_eq_other_index_false() {
+        let coords1 = vec![0., 3., 1., 4., 2., 5.];
+        let buf1 = InterleavedCoordBuffer::new(coords1.into());
+        let coord1 = buf1.value(0);
+
+        let coords2 = vec![0., 3., 100., 400., 200., 500.];
+        let buf2 = InterleavedCoordBuffer::new(coords2.into());
+        let coord2 = buf2.value(0);
+
+        assert_eq!(coord1, coord2);
+    }
+
+    #[test]
+    fn test_eq_against_separated_coord() {
+        let coords1 = vec![0., 3., 1., 4., 2., 5.];
+        let buf1 = InterleavedCoordBuffer::new(coords1.into());
+        let coord1 = buf1.value(0);
+
+        let x = vec![0.];
+        let y = vec![3.];
+        let buf2 = SeparatedCoordBuffer::new(x.into(), y.into());
+        let coord2 = buf2.value(0);
+
+        assert_eq!(coord1, coord2);
     }
 }

--- a/src/scalar/coord/interleaved/scalar.rs
+++ b/src/scalar/coord/interleaved/scalar.rs
@@ -1,6 +1,8 @@
 use arrow2::buffer::Buffer;
 use rstar::{RTreeObject, AABB};
 
+use crate::geo_traits::CoordTrait;
+use crate::scalar::SeparatedCoord;
 use crate::trait_::GeometryScalarTrait;
 
 #[derive(Debug, Clone, PartialEq)]
@@ -26,8 +28,8 @@ impl From<InterleavedCoord<'_>> for geo::Coord {
 impl From<&InterleavedCoord<'_>> for geo::Coord {
     fn from(value: &InterleavedCoord) -> Self {
         geo::Coord {
-            x: *value.coords.get(value.i * 2).unwrap(),
-            y: *value.coords.get(value.i * 2 + 1).unwrap(),
+            x: value.x(),
+            y: value.y(),
         }
     }
 }
@@ -49,6 +51,36 @@ impl RTreeObject for InterleavedCoord<'_> {
     type Envelope = AABB<[f64; 2]>;
 
     fn envelope(&self) -> Self::Envelope {
-        AABB::from_point([self.coords[self.i * 2], self.coords[self.i * 2 + 1]])
+        AABB::from_point([self.x(), self.y()])
+    }
+}
+
+impl PartialEq<SeparatedCoord<'_>> for InterleavedCoord<'_> {
+    fn eq(&self, other: &SeparatedCoord<'_>) -> bool {
+        self.x_y() == other.x_y()
+    }
+}
+
+impl CoordTrait for InterleavedCoord<'_> {
+    type T = f64;
+
+    fn x(&self) -> Self::T {
+        *self.coords.get(self.i * 2).unwrap()
+    }
+
+    fn y(&self) -> Self::T {
+        *self.coords.get(self.i * 2 + 1).unwrap()
+    }
+}
+
+impl CoordTrait for &InterleavedCoord<'_> {
+    type T = f64;
+
+    fn x(&self) -> Self::T {
+        *self.coords.get(self.i * 2).unwrap()
+    }
+
+    fn y(&self) -> Self::T {
+        *self.coords.get(self.i * 2 + 1).unwrap()
     }
 }

--- a/src/scalar/coord/separated/scalar.rs
+++ b/src/scalar/coord/separated/scalar.rs
@@ -1,7 +1,8 @@
+use crate::geo_traits::CoordTrait;
+use crate::scalar::InterleavedCoord;
+use crate::trait_::GeometryScalarTrait;
 use arrow2::buffer::Buffer;
 use rstar::{RTreeObject, AABB};
-
-use crate::trait_::GeometryScalarTrait;
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct SeparatedCoord<'a> {
@@ -26,8 +27,8 @@ impl From<SeparatedCoord<'_>> for geo::Coord {
 impl From<&SeparatedCoord<'_>> for geo::Coord {
     fn from(value: &SeparatedCoord) -> Self {
         geo::Coord {
-            x: *value.x.get(value.i).unwrap(),
-            y: *value.y.get(value.i).unwrap(),
+            x: value.x(),
+            y: value.y(),
         }
     }
 }
@@ -49,6 +50,36 @@ impl RTreeObject for SeparatedCoord<'_> {
     type Envelope = AABB<[f64; 2]>;
 
     fn envelope(&self) -> Self::Envelope {
-        AABB::from_point([self.x[self.i], self.y[self.i]])
+        AABB::from_point([self.x(), self.y()])
+    }
+}
+
+impl PartialEq<InterleavedCoord<'_>> for SeparatedCoord<'_> {
+    fn eq(&self, other: &InterleavedCoord) -> bool {
+        self.x_y() == other.x_y()
+    }
+}
+
+impl CoordTrait for SeparatedCoord<'_> {
+    type T = f64;
+
+    fn x(&self) -> Self::T {
+        self.x[self.i]
+    }
+
+    fn y(&self) -> Self::T {
+        self.y[self.i]
+    }
+}
+
+impl CoordTrait for &SeparatedCoord<'_> {
+    type T = f64;
+
+    fn x(&self) -> Self::T {
+        self.x[self.i]
+    }
+
+    fn y(&self) -> Self::T {
+        self.y[self.i]
     }
 }

--- a/src/scalar/multipolygon/scalar.rs
+++ b/src/scalar/multipolygon/scalar.rs
@@ -121,8 +121,6 @@ impl<O: Offset> PartialEq for MultiPolygon<'_, O> {
     }
 }
 
-
-
 #[cfg(test)]
 mod test {
     use crate::array::MultiPolygonArray;

--- a/src/scalar/multipolygon/scalar.rs
+++ b/src/scalar/multipolygon/scalar.rs
@@ -9,7 +9,7 @@ use arrow2::types::Offset;
 use rstar::{RTreeObject, AABB};
 
 /// An Arrow equivalent of a MultiPolygon
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone)]
 pub struct MultiPolygon<'a, O: Offset> {
     pub coords: &'a CoordBuffer,
 
@@ -102,5 +102,40 @@ impl<O: Offset> RTreeObject for MultiPolygon<'_, O> {
     fn envelope(&self) -> Self::Envelope {
         let (lower, upper) = bounding_rect_multipolygon(self);
         AABB::from_corners(lower, upper)
+    }
+}
+
+impl<O: Offset> PartialEq for MultiPolygon<'_, O> {
+    fn eq(&self, other: &Self) -> bool {
+        if self.num_polygons() != other.num_polygons() {
+            return false;
+        }
+
+        for i in 0..self.num_polygons() {
+            if self.polygon(i) != other.polygon(i) {
+                return false;
+            }
+        }
+
+        true
+    }
+}
+
+
+
+#[cfg(test)]
+mod test {
+    use crate::array::MultiPolygonArray;
+    use crate::test::multipolygon::{mp0, mp1};
+    use crate::GeometryArrayTrait;
+
+    /// Test Eq where the current index is true but another index is false
+    #[test]
+    fn test_eq_other_index_false() {
+        let arr1: MultiPolygonArray<i32> = vec![mp0(), mp1()].into();
+        let arr2: MultiPolygonArray<i32> = vec![mp0(), mp0()].into();
+
+        assert_eq!(arr1.value(0), arr2.value(0));
+        assert_ne!(arr1.value(1), arr2.value(1));
     }
 }

--- a/src/scalar/point/scalar.rs
+++ b/src/scalar/point/scalar.rs
@@ -5,7 +5,7 @@ use crate::trait_::GeometryScalarTrait;
 use rstar::{RTreeObject, AABB};
 
 /// An Arrow equivalent of a Point
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone)]
 pub struct Point<'a> {
     pub coords: &'a CoordBuffer,
     pub geom_index: usize,
@@ -94,5 +94,33 @@ impl RTreeObject for Point<'_> {
     fn envelope(&self) -> Self::Envelope {
         let (lower, upper) = bounding_rect_point(self);
         AABB::from_corners(lower, upper)
+    }
+}
+
+impl PartialEq for Point<'_> {
+    fn eq(&self, other: &Self) -> bool {
+        PointTrait::x_y(&self) == PointTrait::x_y(other)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::array::{CoordBuffer, PointArray};
+    use crate::GeometryArrayTrait;
+
+    /// Test Eq where the current index is true but another index is false
+    #[test]
+    fn test_eq_other_index_false() {
+        let x1 = vec![0., 1., 2.];
+        let y1 = vec![3., 4., 5.];
+        let buf1 = CoordBuffer::Separated((x1, y1).try_into().unwrap());
+        let arr1 = PointArray::new(buf1, None);
+
+        let x2 = vec![0., 100., 2.];
+        let y2 = vec![3., 400., 5.];
+        let buf2 = CoordBuffer::Separated((x2, y2).try_into().unwrap());
+        let arr2 = PointArray::new(buf2, None);
+
+        assert_eq!(arr1.value(0), arr2.value(0));
     }
 }

--- a/src/scalar/polygon/scalar.rs
+++ b/src/scalar/polygon/scalar.rs
@@ -125,7 +125,6 @@ impl<O: Offset> PartialEq for Polygon<'_, O> {
     }
 }
 
-
 #[cfg(test)]
 mod test {
     use crate::array::PolygonArray;

--- a/src/scalar/polygon/scalar.rs
+++ b/src/scalar/polygon/scalar.rs
@@ -10,7 +10,7 @@ use arrow2::types::Offset;
 use rstar::{RTreeObject, AABB};
 
 /// An Arrow equivalent of a Polygon
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone)]
 pub struct Polygon<'a, O: Offset> {
     pub coords: &'a CoordBuffer,
 
@@ -97,5 +97,48 @@ impl<O: Offset> RTreeObject for Polygon<'_, O> {
     fn envelope(&self) -> Self::Envelope {
         let (lower, upper) = bounding_rect_polygon(self);
         AABB::from_corners(lower, upper)
+    }
+}
+
+impl<O: Offset> PartialEq for Polygon<'_, O> {
+    fn eq(&self, other: &Self) -> bool {
+        // TODO: there's probably a way to use the underlying arrays for equality directly, instead
+        // of going through the trait API, but that takes a little more thought to implement
+        // correctly. In particular, you can't just check whether the coord arrays are equal; you
+        // also need to make sure the ring start and ends are equal. But the ring offsets may be
+        // different
+        if self.num_interiors() != other.num_interiors() {
+            return false;
+        }
+
+        if self.exterior() != other.exterior() {
+            return false;
+        }
+
+        for i in 0..self.num_interiors() {
+            if self.interior(i) != other.interior(i) {
+                return false;
+            }
+        }
+
+        true
+    }
+}
+
+
+#[cfg(test)]
+mod test {
+    use crate::array::PolygonArray;
+    use crate::test::polygon::{p0, p1};
+    use crate::GeometryArrayTrait;
+
+    /// Test Eq where the current index is true but another index is false
+    #[test]
+    fn test_eq_other_index_false() {
+        let arr1: PolygonArray<i32> = vec![p0(), p1()].into();
+        let arr2: PolygonArray<i32> = vec![p0(), p0()].into();
+
+        assert_eq!(arr1.value(0), arr2.value(0));
+        assert_ne!(arr1.value(1), arr2.value(1));
     }
 }

--- a/src/scalar/rect/scalar.rs
+++ b/src/scalar/rect/scalar.rs
@@ -3,7 +3,7 @@ use rstar::{RTreeObject, AABB};
 
 use crate::trait_::GeometryScalarTrait;
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone)]
 pub struct Rect<'a> {
     pub values: &'a Buffer<f64>,
     pub geom_index: usize,
@@ -60,5 +60,11 @@ impl RTreeObject for Rect<'_> {
         let maxx = self.values[self.geom_index * 4 + 2];
         let maxy = self.values[self.geom_index * 4 + 3];
         AABB::from_corners([minx, miny], [maxx, maxy])
+    }
+}
+
+impl PartialEq for Rect<'_> {
+    fn eq(&self, other: &Self) -> bool {
+        self.lower() == other.lower() && self.upper() == other.upper()
     }
 }


### PR DESCRIPTION
### Change list

- Implemented `PartialEq` for the various `CoordBuffer` and `Coord` types.
  - In particular, the derived `PartialEq` called it on all constituent types. But if you have a scalar that's a reference on a larger array, then it would indicate `false` if _any_ item in the array were unequal, not just the specific point of interest.

Closes https://github.com/kylebarron/geoarrow-rs/issues/80