### PR TITLE
Mixed geometry array

### DIFF
--- a/src/array/linestring/array.rs
+++ b/src/array/linestring/array.rs
@@ -388,6 +388,13 @@ impl TryFrom<LineStringArray<i64>> for LineStringArray<i32> {
     }
 }
 
+/// Default to an empty array
+impl<O: Offset> Default for LineStringArray<O> {
+    fn default() -> Self {
+        MutableLineStringArray::default().into()
+    }
+}
+
 #[cfg(test)]
 mod test {
     use crate::test::geoarrow_data::{

--- a/src/array/mixed/array.rs
+++ b/src/array/mixed/array.rs
@@ -349,10 +349,39 @@ impl<O: Offset> MixedGeometryArray<O> {
     }
 }
 
+// impl<O: Offset> TryFrom<&UnionArray> for MixedGeometryArray<i32> {
+//     type Error = GeoArrowError;
+
+//     fn try_from(value: &UnionArray) -> std::result::Result<Self, Self::Error> {
+//         let types = value.types().clone();
+//         let offsets = value.offsets().unwrap().clone();
+//         let fields = value.fields();
+
+//         let parsed_fields: Vec<GeometryArray<i32>> = value
+//             .fields()
+//             .into_iter()
+//             .map(|arr| arr.as_ref().try_into().unwrap())
+//             .collect();
+
+//         // todo: convert parsed fields into a concrete array of each type.
+
+//         Ok(Self::new(
+//             types,
+//             offsets,
+//             points,
+//             line_strings,
+//             polygons,
+//             multi_points,
+//             multi_line_strings,
+//             multi_polygons,
+//         ))
+//     }
+// }
+
 impl<O: Offset> TryFrom<Vec<geo::Geometry>> for MixedGeometryArray<O> {
     type Error = GeoArrowError;
 
-    fn try_from(value: Vec<geo::Geometry>) -> Result<Self, Self::Error> {
+    fn try_from(value: Vec<geo::Geometry>) -> std::result::Result<Self, Self::Error> {
         let mut_arr: MutableMixedGeometryArray<O> = value.try_into()?;
         Ok(mut_arr.into())
     }

--- a/src/array/mixed/array.rs
+++ b/src/array/mixed/array.rs
@@ -110,7 +110,7 @@ impl<'a, O: Offset> GeometryArrayTrait<'a> for MixedGeometryArray<O> {
 
     fn into_arrow(self) -> Self::ArrowArray {
         let extension_type = self.extension_type();
-        let mut fields = vec![
+        let fields = vec![
             self.points.into_boxed_arrow(),
             self.line_strings.into_boxed_arrow(),
             self.polygons.into_boxed_arrow(),
@@ -140,8 +140,7 @@ impl<'a, O: Offset> GeometryArrayTrait<'a> for MixedGeometryArray<O> {
 
     /// Build a spatial index containing this array's geometries
     fn rstar_tree(&'a self) -> RTree<Self::RTreeObject> {
-        todo!()
-        // RTree::bulk_load(self.iter().flatten().map(CachedEnvelope::new).collect())
+        RTree::bulk_load(self.iter().flatten().map(CachedEnvelope::new).collect())
     }
 
     /// Returns the number of geometries in this array

--- a/src/array/mixed/array.rs
+++ b/src/array/mixed/array.rs
@@ -1,0 +1,235 @@
+use arrow2::array::UnionArray;
+use arrow2::bitmap::Bitmap;
+use arrow2::buffer::Buffer;
+use arrow2::datatypes::DataType;
+use arrow2::types::Offset;
+use rstar::primitives::CachedEnvelope;
+use rstar::RTree;
+
+use crate::array::{
+    LineStringArray, MultiLineStringArray, MultiPointArray, MultiPolygonArray, PointArray,
+    PolygonArray,
+};
+use crate::scalar::Geometry;
+use crate::GeometryArrayTrait;
+
+/// # Invariants
+///
+/// - All arrays must have the same dimension
+/// - All arrays must have the same coordinate layout (interleaved or separated)
+#[derive(Debug, Clone, PartialEq)]
+pub struct MixedGeometryArray<O: Offset> {
+    // Invariant: every item in `types` is `> 0 && < fields.len()`
+    // - 0: PointArray
+    // - 1: LineStringArray
+    // - 2: PolygonArray
+    // - 3: MultiPointArray
+    // - 4: MultiLineStringArray
+    // - 5: MultiPolygonArray
+    types: Buffer<i8>,
+
+    /// Note that we include an ordering so that exporting this array to Arrow is O(1). If we used
+    /// another ordering like always Point, LineString, etc. then we'd either have to always export
+    /// all arrays (including some zero-length arrays) or have to reorder the `types` buffer when
+    /// exporting.
+    // ordering: Vec<>,
+    points: PointArray,
+    line_strings: LineStringArray<O>,
+    polygons: PolygonArray<O>,
+    multi_points: MultiPointArray<O>,
+    multi_line_strings: MultiLineStringArray<O>,
+    multi_polygons: MultiPolygonArray<O>,
+
+    // Invariant: `offsets.len() == types.len()`
+    offsets: Buffer<i32>,
+}
+
+enum MixedGeometryOrdering {
+    Point = 0,
+    LineString = 1,
+    Polygon = 2,
+    MultiPoint = 3,
+    MultiLineString = 4,
+    MultiPolygon = 5,
+}
+
+impl From<i8> for MixedGeometryOrdering {
+    fn from(value: i8) -> Self {
+        match value {
+            0 => MixedGeometryOrdering::Point,
+            1 => MixedGeometryOrdering::LineString,
+            2 => MixedGeometryOrdering::Polygon,
+            3 => MixedGeometryOrdering::MultiPoint,
+            4 => MixedGeometryOrdering::MultiLineString,
+            5 => MixedGeometryOrdering::MultiPolygon,
+            _ => panic!(),
+        }
+    }
+}
+
+impl<'a, O: Offset> GeometryArrayTrait<'a> for MixedGeometryArray<O> {
+    type Scalar = Geometry<'a, O>;
+    type ScalarGeo = geo::Geometry;
+    type ArrowArray = UnionArray;
+    type RTreeObject = CachedEnvelope<Self::Scalar>;
+
+    /// Gets the value at slot `i`
+    fn value(&'a self, i: usize) -> Self::Scalar {
+        let index = self.types[i];
+        let geometry_type = MixedGeometryOrdering::from(index);
+        let offset = self.offsets[index as usize] as usize;
+        match geometry_type {
+            MixedGeometryOrdering::Point => Geometry::Point(self.points.value(offset)),
+            MixedGeometryOrdering::LineString => {
+                Geometry::LineString(self.line_strings.value(offset))
+            }
+            MixedGeometryOrdering::Polygon => Geometry::Polygon(self.polygons.value(offset)),
+            MixedGeometryOrdering::MultiPoint => {
+                Geometry::MultiPoint(self.multi_points.value(offset))
+            }
+            MixedGeometryOrdering::MultiLineString => {
+                Geometry::MultiLineString(self.multi_line_strings.value(offset))
+            }
+            MixedGeometryOrdering::MultiPolygon => {
+                Geometry::MultiPolygon(self.multi_polygons.value(offset))
+            }
+        }
+    }
+
+    fn logical_type(&self) -> DataType {
+        todo!();
+    }
+
+    fn extension_type(&self) -> DataType {
+        DataType::Extension(
+            "geoarrow.mixed".to_string(),
+            Box::new(self.logical_type()),
+            None,
+        )
+    }
+
+    fn into_arrow(self) -> Self::ArrowArray {
+        let extension_type = self.extension_type();
+        let mut fields = vec![
+            self.points.into_boxed_arrow(),
+            self.line_strings.into_boxed_arrow(),
+            self.polygons.into_boxed_arrow(),
+            self.multi_points.into_boxed_arrow(),
+            self.multi_line_strings.into_boxed_arrow(),
+            self.multi_polygons.into_boxed_arrow(),
+        ];
+
+        UnionArray::new(extension_type, self.types, fields, Some(self.offsets))
+    }
+
+    fn into_boxed_arrow(self) -> Box<dyn arrow2::array::Array> {
+        self.into_arrow().boxed()
+    }
+
+    fn with_coords(self, coords: crate::array::CoordBuffer) -> Self {
+        todo!();
+    }
+
+    fn coord_type(&self) -> crate::array::CoordType {
+        todo!();
+    }
+
+    fn into_coord_type(self, coord_type: crate::array::CoordType) -> Self {
+        todo!();
+    }
+
+    /// Build a spatial index containing this array's geometries
+    fn rstar_tree(&'a self) -> RTree<Self::RTreeObject> {
+        todo!()
+        // RTree::bulk_load(self.iter().flatten().map(CachedEnvelope::new).collect())
+    }
+
+    /// Returns the number of geometries in this array
+    #[inline]
+    fn len(&self) -> usize {
+        self.types.len()
+    }
+
+    /// Returns the optional validity.
+    #[inline]
+    fn validity(&self) -> Option<&Bitmap> {
+        None
+    }
+
+    /// Slices this [`MixedGeometryArray`] in place.
+    ///
+    /// # Implementation
+    /// This operation is `O(1)` as it amounts to increase two ref counts.
+    /// # Examples
+    /// ```
+    /// use arrow2::array::PrimitiveArray;
+    ///
+    /// let array = PrimitiveArray::from_vec(vec![1, 2, 3]);
+    /// assert_eq!(format!("{:?}", array), "Int32[1, 2, 3]");
+    /// let sliced = array.slice(1, 1);
+    /// assert_eq!(format!("{:?}", sliced), "Int32[2]");
+    /// // note: `sliced` and `array` share the same memory region.
+    /// ```
+    /// # Panic
+    /// This function panics iff `offset + length > self.len()`.
+    #[inline]
+    fn slice(&mut self, offset: usize, length: usize) {
+        assert!(
+            offset + length <= self.len(),
+            "offset + length may not exceed length of array"
+        );
+        unsafe { self.slice_unchecked(offset, length) }
+    }
+
+    /// Slices this [`MixedGeometryArray`] in place.
+    ///
+    /// # Implementation
+    /// This operation is `O(1)` as it amounts to increase two ref counts.
+    /// # Safety
+    /// The caller must ensure that `offset + length <= self.len()`.
+    #[inline]
+    unsafe fn slice_unchecked(&mut self, offset: usize, length: usize) {
+        todo!()
+    }
+
+    fn to_boxed(&self) -> Box<Self> {
+        Box::new(self.clone())
+    }
+}
+
+// Implement geometry accessors
+impl<O: Offset> MixedGeometryArray<O> {
+    /// Iterator over geo Geometry objects, not looking at validity
+    pub fn iter_geo_values(&self) -> impl Iterator<Item = geo::Geometry> + '_ {
+        (0..self.len()).map(|i| self.value_as_geo(i))
+    }
+
+    /// Iterator over geo Geometry objects, taking into account validity
+    pub fn iter_geo(&self) -> impl Iterator<Item = Option<geo::Geometry>> + '_ {
+        (0..self.len()).map(|i| self.get_as_geo(i))
+    }
+
+    /// Returns the value at slot `i` as a GEOS geometry.
+    #[cfg(feature = "geos")]
+    pub fn value_as_geos(&self, i: usize) -> geos::Geometry {
+        self.value(i).try_into().unwrap()
+    }
+
+    /// Gets the value at slot `i` as a GEOS geometry, additionally checking the validity bitmap
+    #[cfg(feature = "geos")]
+    pub fn get_as_geos(&self, i: usize) -> Option<geos::Geometry> {
+        self.get(i).map(|geom| geom.try_into().unwrap())
+    }
+
+    /// Iterator over GEOS geometry objects
+    #[cfg(feature = "geos")]
+    pub fn iter_geos_values(&self) -> impl Iterator<Item = geos::Geometry> + '_ {
+        (0..self.len()).map(|i| self.value_as_geos(i))
+    }
+
+    /// Iterator over GEOS geometry objects, taking validity into account
+    #[cfg(feature = "geos")]
+    pub fn iter_geos(&self) -> impl Iterator<Item = Option<geos::Geometry>> + '_ {
+        (0..self.len()).map(|i| self.get_as_geos(i))
+    }
+}

--- a/src/array/mixed/iterator.rs
+++ b/src/array/mixed/iterator.rs
@@ -1,0 +1,82 @@
+use crate::array::MixedGeometryArray;
+use crate::scalar::Geometry;
+use crate::GeometryArrayTrait;
+use arrow2::bitmap::utils::{BitmapIter, ZipValidity};
+use arrow2::trusted_len::TrustedLen;
+use arrow2::types::Offset;
+
+/// Iterator of values of a [`MixedGeometryArray`]
+#[derive(Clone, Debug)]
+pub struct MixedGeometryArrayValuesIter<'a, O: Offset> {
+    array: &'a MixedGeometryArray<O>,
+    index: usize,
+    end: usize,
+}
+
+impl<'a, O: Offset> MixedGeometryArrayValuesIter<'a, O> {
+    #[inline]
+    pub fn new(array: &'a MixedGeometryArray<O>) -> Self {
+        Self {
+            array,
+            index: 0,
+            end: array.len(),
+        }
+    }
+}
+
+impl<'a, O: Offset> Iterator for MixedGeometryArrayValuesIter<'a, O> {
+    type Item = Geometry<'a, O>;
+
+    #[inline]
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.index == self.end {
+            return None;
+        }
+        let old = self.index;
+        self.index += 1;
+        Some(self.array.value(old))
+    }
+
+    #[inline]
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        (self.end - self.index, Some(self.end - self.index))
+    }
+}
+
+unsafe impl<'a, O: Offset> TrustedLen for MixedGeometryArrayValuesIter<'a, O> {}
+
+impl<'a, O: Offset> DoubleEndedIterator for MixedGeometryArrayValuesIter<'a, O> {
+    #[inline]
+    fn next_back(&mut self) -> Option<Self::Item> {
+        if self.index == self.end {
+            None
+        } else {
+            self.end -= 1;
+            Some(self.array.value(self.end))
+        }
+    }
+}
+
+impl<'a, O: Offset> IntoIterator for &'a MixedGeometryArray<O> {
+    type Item = Option<Geometry<'a, O>>;
+    type IntoIter =
+        ZipValidity<Geometry<'a, O>, MixedGeometryArrayValuesIter<'a, O>, BitmapIter<'a>>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter()
+    }
+}
+
+impl<'a, O: Offset> MixedGeometryArray<O> {
+    /// Returns an iterator of `Option<Point>`
+    pub fn iter(
+        &'a self,
+    ) -> ZipValidity<Geometry<'a, O>, MixedGeometryArrayValuesIter<'a, O>, BitmapIter<'a>> {
+        ZipValidity::new_with_validity(MixedGeometryArrayValuesIter::new(self), self.validity())
+    }
+
+    /// Returns an iterator of `Point`
+    pub fn values_iter(&'a self) -> MixedGeometryArrayValuesIter<'a, O> {
+        MixedGeometryArrayValuesIter::new(self)
+    }
+}

--- a/src/array/mixed/mod.rs
+++ b/src/array/mixed/mod.rs
@@ -1,0 +1,1 @@
+pub mod array;

--- a/src/array/mixed/mod.rs
+++ b/src/array/mixed/mod.rs
@@ -2,3 +2,4 @@ pub use array::MixedGeometryArray;
 
 pub mod array;
 mod iterator;
+pub mod mutable;

--- a/src/array/mixed/mod.rs
+++ b/src/array/mixed/mod.rs
@@ -1,4 +1,5 @@
 pub use array::MixedGeometryArray;
+pub use mutable::MutableMixedGeometryArray;
 
 pub mod array;
 mod iterator;

--- a/src/array/mixed/mod.rs
+++ b/src/array/mixed/mod.rs
@@ -1,1 +1,4 @@
+pub use array::MixedGeometryArray;
+
 pub mod array;
+mod iterator;

--- a/src/array/mixed/mutable.rs
+++ b/src/array/mixed/mutable.rs
@@ -1,4 +1,4 @@
-use crate::array::mixed::array::MixedGeometryOrdering;
+use crate::array::mixed::array::GeometryType;
 use crate::array::{
     MixedGeometryArray, MutableLineStringArray, MutableMultiLineStringArray,
     MutableMultiPointArray, MutableMultiPolygonArray, MutablePointArray, MutablePolygonArray,
@@ -165,8 +165,7 @@ impl<'a, O: Offset> MutableMixedGeometryArray<O> {
         self.offsets.push(self.point_counter);
         self.point_counter += 1;
 
-        self.types
-            .push(MixedGeometryOrdering::Point.default_ordering());
+        self.types.push(GeometryType::Point.default_ordering());
         self.points.push_point(value)
     }
 
@@ -180,8 +179,7 @@ impl<'a, O: Offset> MutableMixedGeometryArray<O> {
         self.offsets.push(self.multi_point_counter);
         self.multi_point_counter += 1;
 
-        self.types
-            .push(MixedGeometryOrdering::MultiPoint.default_ordering());
+        self.types.push(GeometryType::MultiPoint.default_ordering());
         self.multi_points.push_point(value)
     }
 
@@ -198,8 +196,7 @@ impl<'a, O: Offset> MutableMixedGeometryArray<O> {
         self.offsets.push(self.line_string_counter);
         self.line_string_counter += 1;
 
-        self.types
-            .push(MixedGeometryOrdering::LineString.default_ordering());
+        self.types.push(GeometryType::LineString.default_ordering());
         self.line_strings.push_line_string(value)
     }
 
@@ -217,7 +214,7 @@ impl<'a, O: Offset> MutableMixedGeometryArray<O> {
         self.multi_line_string_counter += 1;
 
         self.types
-            .push(MixedGeometryOrdering::MultiLineString.default_ordering());
+            .push(GeometryType::MultiLineString.default_ordering());
         self.multi_line_strings.push_line_string(value)
     }
 
@@ -231,8 +228,7 @@ impl<'a, O: Offset> MutableMixedGeometryArray<O> {
         self.offsets.push(self.polygon_counter);
         self.polygon_counter += 1;
 
-        self.types
-            .push(MixedGeometryOrdering::Polygon.default_ordering());
+        self.types.push(GeometryType::Polygon.default_ordering());
         self.polygons.push_polygon(value)
     }
 
@@ -250,7 +246,7 @@ impl<'a, O: Offset> MutableMixedGeometryArray<O> {
         self.multi_polygon_counter += 1;
 
         self.types
-            .push(MixedGeometryOrdering::MultiPolygon.default_ordering());
+            .push(GeometryType::MultiPolygon.default_ordering());
         self.multi_polygons.push_polygon(value)
     }
 
@@ -266,8 +262,7 @@ impl<'a, O: Offset> MutableMixedGeometryArray<O> {
         self.offsets.push(self.multi_point_counter);
         self.multi_point_counter += 1;
 
-        self.types
-            .push(MixedGeometryOrdering::MultiPoint.default_ordering());
+        self.types.push(GeometryType::MultiPoint.default_ordering());
         self.multi_points.push_multi_point(value)
     }
 
@@ -284,7 +279,7 @@ impl<'a, O: Offset> MutableMixedGeometryArray<O> {
         self.multi_line_string_counter += 1;
 
         self.types
-            .push(MixedGeometryOrdering::MultiLineString.default_ordering());
+            .push(GeometryType::MultiLineString.default_ordering());
         self.multi_line_strings.push_multi_line_string(value)
     }
 
@@ -301,7 +296,7 @@ impl<'a, O: Offset> MutableMixedGeometryArray<O> {
         self.multi_polygon_counter += 1;
 
         self.types
-            .push(MixedGeometryOrdering::MultiPolygon.default_ordering());
+            .push(GeometryType::MultiPolygon.default_ordering());
         self.multi_polygons.push_multi_polygon(value)
     }
 }

--- a/src/array/mixed/mutable.rs
+++ b/src/array/mixed/mutable.rs
@@ -1,0 +1,347 @@
+use crate::array::mixed::array::MixedGeometryOrdering;
+use crate::array::{
+    MixedGeometryArray, MutableLineStringArray, MutableMultiLineStringArray,
+    MutableMultiPointArray, MutableMultiPolygonArray, MutablePointArray, MutablePolygonArray,
+};
+use crate::error::Result;
+use crate::geo_traits::*;
+use arrow2::types::Offset;
+
+/// The Arrow equivalent to a `Vec<Option<Geometry>>` with the caveat that these geometries must be
+/// a _primitive_ geometry type. That means this does not support Geometry::GeometryCollection.
+///
+/// # Invariants
+///
+/// - All arrays must have the same dimension
+/// - All arrays must have the same coordinate layout (interleaved or separated)
+#[derive(Debug, Clone)]
+pub struct MutableMixedGeometryArray<O: Offset> {
+    // Invariant: every item in `types` is `> 0 && < fields.len()`
+    // - 0: PointArray
+    // - 1: LineStringArray
+    // - 2: PolygonArray
+    // - 3: MultiPointArray
+    // - 4: MultiLineStringArray
+    // - 5: MultiPolygonArray
+    types: Vec<i8>,
+
+    /// Note that we include an ordering so that exporting this array to Arrow is O(1). If we used
+    /// another ordering like always Point, LineString, etc. then we'd either have to always export
+    /// all arrays (including some zero-length arrays) or have to reorder the `types` buffer when
+    /// exporting.
+    // ordering: Vec<>,
+    points: MutablePointArray,
+    line_strings: MutableLineStringArray<O>,
+    polygons: MutablePolygonArray<O>,
+    multi_points: MutableMultiPointArray<O>,
+    multi_line_strings: MutableMultiLineStringArray<O>,
+    multi_polygons: MutableMultiPolygonArray<O>,
+
+    // The offset of the _next_ geometry to be pushed into these arrays
+    // This is necessary to maintain so that we can efficiently update `offsets` below
+    point_counter: i32,
+    line_string_counter: i32,
+    polygon_counter: i32,
+    multi_point_counter: i32,
+    multi_line_string_counter: i32,
+    multi_polygon_counter: i32,
+
+    // Invariant: `offsets.len() == types.len()`
+    offsets: Vec<i32>,
+}
+
+impl<'a, O: Offset> MutableMixedGeometryArray<O> {
+    /// Creates a new empty [`MutableMixedGeometryArray`].
+    pub fn new() -> Self {
+        Self {
+            types: vec![],
+            points: MutablePointArray::new(),
+            line_strings: MutableLineStringArray::new(),
+            polygons: MutablePolygonArray::new(),
+            multi_points: MutableMultiPointArray::new(),
+            multi_line_strings: MutableMultiLineStringArray::new(),
+            multi_polygons: MutableMultiPolygonArray::new(),
+            point_counter: 0,
+            line_string_counter: 0,
+            polygon_counter: 0,
+            multi_point_counter: 0,
+            multi_line_string_counter: 0,
+            multi_polygon_counter: 0,
+            offsets: vec![],
+        }
+    }
+
+    /// Reserve capacity for at least `additional` more geometries.
+    pub fn reserve_geometries(&mut self, additional: usize) {
+        self.types.reserve(additional);
+        self.offsets.reserve(additional);
+    }
+
+    /// Reserve capacity for at least `additional` more Points.
+    pub fn reserve_points(&mut self, additional: usize) {
+        self.points.reserve(additional);
+    }
+
+    /// Reserve capacity for at least `additional` more LineStrings.
+    pub fn reserve_line_strings(&mut self, coord_additional: usize, geom_additional: usize) {
+        self.line_strings.reserve(coord_additional, geom_additional);
+    }
+
+    /// Reserve capacity for at least `additional` more Polygons.
+    pub fn reserve_polygons(
+        &mut self,
+        coord_additional: usize,
+        ring_additional: usize,
+        geom_additional: usize,
+    ) {
+        self.polygons
+            .reserve(coord_additional, ring_additional, geom_additional)
+    }
+
+    /// Reserve capacity for at least `additional` more MultiPoints.
+    pub fn reserve_multi_points(&mut self, coord_additional: usize, geom_additional: usize) {
+        self.multi_points.reserve(coord_additional, geom_additional)
+    }
+
+    /// Reserve capacity for at least `additional` more MultiLineStrings.
+    pub fn reserve_multi_line_strings(
+        &mut self,
+        coord_additional: usize,
+        ring_additional: usize,
+        geom_additional: usize,
+    ) {
+        self.multi_line_strings
+            .reserve(coord_additional, ring_additional, geom_additional)
+    }
+
+    /// Reserve capacity for at least `additional` more MultiPolygons.
+    pub fn reserve_multi_polygons(
+        &mut self,
+        coord_additional: usize,
+        ring_additional: usize,
+        polygon_additional: usize,
+        geom_additional: usize,
+    ) {
+        self.multi_polygons.reserve(
+            coord_additional,
+            ring_additional,
+            polygon_additional,
+            geom_additional,
+        )
+    }
+
+    // /// The canonical method to create a [`MutableMixedGeometryArray`] out of its internal
+    // /// components.
+    // ///
+    // /// # Implementation
+    // ///
+    // /// This function is `O(1)`.
+    // ///
+    // /// # Errors
+    // ///
+    // pub fn try_new(
+    //     coords: MutableCoordBuffer,
+    //     geom_offsets: Offsets<O>,
+    //     ring_offsets: Offsets<O>,
+    //     validity: Option<MutableBitmap>,
+    // ) -> Result<Self> {
+    //     check(
+    //         &coords.clone().into(),
+    //         &geom_offsets.clone().into(),
+    //         &ring_offsets.clone().into(),
+    //         validity.as_ref().map(|x| x.len()),
+    //     )?;
+    //     Ok(Self {
+    //         coords,
+    //         geom_offsets,
+    //         ring_offsets,
+    //         validity,
+    //     })
+    // }
+
+    /// Add a new Point to the end of this array, storing it in the MutablePointArray child array.
+    #[inline]
+    pub fn push_point(&mut self, value: Option<impl PointTrait<T = f64>>) {
+        self.offsets.push(self.point_counter);
+        self.point_counter += 1;
+
+        self.types.push(MixedGeometryOrdering::Point.into());
+        self.points.push_point(value)
+    }
+
+    /// Add a new Point to the end of this array, storing it in the MutableMultiPointArray child
+    /// array.
+    #[inline]
+    pub fn push_point_as_multi_point(
+        &mut self,
+        value: Option<impl PointTrait<T = f64>>,
+    ) -> Result<()> {
+        self.offsets.push(self.multi_point_counter);
+        self.multi_point_counter += 1;
+
+        // TODO: fix offsets
+        self.types.push(MixedGeometryOrdering::MultiPoint.into());
+        self.multi_points.push_point(value)
+    }
+
+    /// Add a new LineString to the end of this array, storing it in the MutableLineStringArray
+    /// child array.
+    ///
+    /// # Errors
+    ///
+    /// This function errors iff the new last item is larger than what O supports.
+    pub fn push_line_string(
+        &mut self,
+        value: Option<impl LineStringTrait<'a, T = f64>>,
+    ) -> Result<()> {
+        self.offsets.push(self.line_string_counter);
+        self.line_string_counter += 1;
+
+        self.types.push(MixedGeometryOrdering::LineString.into());
+        self.line_strings.push_line_string(value)
+    }
+
+    /// Add a new LineString to the end of this array, storing it in the
+    /// MutableMultiLineStringArray child array.
+    ///
+    /// # Errors
+    ///
+    /// This function errors iff the new last item is larger than what O supports.
+    pub fn push_line_string_as_multi_line_string(
+        &mut self,
+        value: Option<impl LineStringTrait<'a, T = f64>>,
+    ) -> Result<()> {
+        self.offsets.push(self.multi_line_string_counter);
+        self.multi_line_string_counter += 1;
+
+        self.types
+            .push(MixedGeometryOrdering::MultiLineString.into());
+        self.multi_line_strings.push_line_string(value)
+    }
+
+    /// Add a new Polygon to the end of this array, storing it in the MutablePolygonArray
+    /// child array.
+    ///
+    /// # Errors
+    ///
+    /// This function errors iff the new last item is larger than what O supports.
+    pub fn push_polygon(&mut self, value: Option<impl PolygonTrait<'a, T = f64>>) -> Result<()> {
+        self.offsets.push(self.polygon_counter);
+        self.polygon_counter += 1;
+
+        self.types.push(MixedGeometryOrdering::Polygon.into());
+        self.polygons.push_polygon(value)
+    }
+
+    /// Add a new Polygon to the end of this array, storing it in the MutableMultiPolygonArray
+    /// child array.
+    ///
+    /// # Errors
+    ///
+    /// This function errors iff the new last item is larger than what O supports.
+    pub fn push_polygon_as_multi_polygon(
+        &mut self,
+        value: Option<impl PolygonTrait<'a, T = f64>>,
+    ) -> Result<()> {
+        self.offsets.push(self.multi_polygon_counter);
+        self.multi_polygon_counter += 1;
+
+        self.types.push(MixedGeometryOrdering::MultiPolygon.into());
+        self.multi_polygons.push_polygon(value)
+    }
+
+    /// Add a new MultiPoint to the end of this array.
+    ///
+    /// # Errors
+    ///
+    /// This function errors iff the new last item is larger than what O supports.
+    pub fn push_multi_point(
+        &mut self,
+        value: Option<impl MultiPointTrait<'a, T = f64>>,
+    ) -> Result<()> {
+        self.offsets.push(self.multi_point_counter);
+        self.multi_point_counter += 1;
+
+        self.types.push(MixedGeometryOrdering::MultiPoint.into());
+        self.multi_points.push_multi_point(value)
+    }
+
+    /// Add a new MultiLineString to the end of this array.
+    ///
+    /// # Errors
+    ///
+    /// This function errors iff the new last item is larger than what O supports.
+    pub fn push_multi_line_string(
+        &mut self,
+        value: Option<impl MultiLineStringTrait<'a, T = f64>>,
+    ) -> Result<()> {
+        self.offsets.push(self.multi_line_string_counter);
+        self.multi_line_string_counter += 1;
+
+        self.types
+            .push(MixedGeometryOrdering::MultiLineString.into());
+        self.multi_line_strings.push_multi_line_string(value)
+    }
+
+    /// Add a new MultiPolygon to the end of this array.
+    ///
+    /// # Errors
+    ///
+    /// This function errors iff the new last item is larger than what O supports.
+    pub fn push_multi_polygon(
+        &mut self,
+        value: Option<impl MultiPolygonTrait<'a, T = f64>>,
+    ) -> Result<()> {
+        self.offsets.push(self.multi_polygon_counter);
+        self.multi_polygon_counter += 1;
+
+        self.types.push(MixedGeometryOrdering::MultiPolygon.into());
+        self.multi_polygons.push_multi_polygon(value)
+    }
+}
+
+impl<O: Offset> Default for MutableMixedGeometryArray<O> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<O: Offset> From<MutableMixedGeometryArray<O>> for MixedGeometryArray<O> {
+    fn from(other: MutableMixedGeometryArray<O>) -> Self {
+        Self::new(
+            other.types.into(),
+            other.offsets.into(),
+            other.points.into(),
+            other.line_strings.into(),
+            other.polygons.into(),
+            other.multi_points.into(),
+            other.multi_line_strings.into(),
+            other.multi_polygons.into(),
+        )
+    }
+}
+
+// TODO: figure out these trait impl errors
+// fn from_geometry_trait_iterator<'a, O: Offset>(
+//     geoms: impl Iterator<Item = impl GeometryTrait<'a, T = f64> + 'a>,
+//     prefer_multi: bool
+// ) -> MutableMixedGeometryArray<O> {
+//     let mut array = MutableMixedGeometryArray::new();
+
+//     for geom in geoms.into_iter() {
+//         match geom.as_type() {
+//             GeometryType::Point(point) => {
+//                 array.push_valid_point(point);
+//                 // if prefer_multi {
+//                 //     array.push_point_as_multi_point(Some(point));
+//                 // } else {
+//                 //     array.push_point(Some(point));
+//                 // }
+//             }
+//             _ => todo!(),
+//         };
+//         // maybe_geom.
+//     }
+
+//     array
+// }

--- a/src/array/mixed/mutable.rs
+++ b/src/array/mixed/mutable.rs
@@ -165,7 +165,8 @@ impl<'a, O: Offset> MutableMixedGeometryArray<O> {
         self.offsets.push(self.point_counter);
         self.point_counter += 1;
 
-        self.types.push(MixedGeometryOrdering::Point.default_ordering());
+        self.types
+            .push(MixedGeometryOrdering::Point.default_ordering());
         self.points.push_point(value)
     }
 
@@ -179,7 +180,8 @@ impl<'a, O: Offset> MutableMixedGeometryArray<O> {
         self.offsets.push(self.multi_point_counter);
         self.multi_point_counter += 1;
 
-        self.types.push(MixedGeometryOrdering::MultiPoint.default_ordering());
+        self.types
+            .push(MixedGeometryOrdering::MultiPoint.default_ordering());
         self.multi_points.push_point(value)
     }
 
@@ -196,7 +198,8 @@ impl<'a, O: Offset> MutableMixedGeometryArray<O> {
         self.offsets.push(self.line_string_counter);
         self.line_string_counter += 1;
 
-        self.types.push(MixedGeometryOrdering::LineString.default_ordering());
+        self.types
+            .push(MixedGeometryOrdering::LineString.default_ordering());
         self.line_strings.push_line_string(value)
     }
 
@@ -228,7 +231,8 @@ impl<'a, O: Offset> MutableMixedGeometryArray<O> {
         self.offsets.push(self.polygon_counter);
         self.polygon_counter += 1;
 
-        self.types.push(MixedGeometryOrdering::Polygon.default_ordering());
+        self.types
+            .push(MixedGeometryOrdering::Polygon.default_ordering());
         self.polygons.push_polygon(value)
     }
 
@@ -245,7 +249,8 @@ impl<'a, O: Offset> MutableMixedGeometryArray<O> {
         self.offsets.push(self.multi_polygon_counter);
         self.multi_polygon_counter += 1;
 
-        self.types.push(MixedGeometryOrdering::MultiPolygon.default_ordering());
+        self.types
+            .push(MixedGeometryOrdering::MultiPolygon.default_ordering());
         self.multi_polygons.push_polygon(value)
     }
 
@@ -261,7 +266,8 @@ impl<'a, O: Offset> MutableMixedGeometryArray<O> {
         self.offsets.push(self.multi_point_counter);
         self.multi_point_counter += 1;
 
-        self.types.push(MixedGeometryOrdering::MultiPoint.default_ordering());
+        self.types
+            .push(MixedGeometryOrdering::MultiPoint.default_ordering());
         self.multi_points.push_multi_point(value)
     }
 
@@ -294,7 +300,8 @@ impl<'a, O: Offset> MutableMixedGeometryArray<O> {
         self.offsets.push(self.multi_polygon_counter);
         self.multi_polygon_counter += 1;
 
-        self.types.push(MixedGeometryOrdering::MultiPolygon.default_ordering());
+        self.types
+            .push(MixedGeometryOrdering::MultiPolygon.default_ordering());
         self.multi_polygons.push_multi_polygon(value)
     }
 }

--- a/src/array/mixed/mutable.rs
+++ b/src/array/mixed/mutable.rs
@@ -165,7 +165,7 @@ impl<'a, O: Offset> MutableMixedGeometryArray<O> {
         self.offsets.push(self.point_counter);
         self.point_counter += 1;
 
-        self.types.push(MixedGeometryOrdering::Point.into());
+        self.types.push(MixedGeometryOrdering::Point.default_ordering());
         self.points.push_point(value)
     }
 
@@ -179,8 +179,7 @@ impl<'a, O: Offset> MutableMixedGeometryArray<O> {
         self.offsets.push(self.multi_point_counter);
         self.multi_point_counter += 1;
 
-        // TODO: fix offsets
-        self.types.push(MixedGeometryOrdering::MultiPoint.into());
+        self.types.push(MixedGeometryOrdering::MultiPoint.default_ordering());
         self.multi_points.push_point(value)
     }
 
@@ -197,7 +196,7 @@ impl<'a, O: Offset> MutableMixedGeometryArray<O> {
         self.offsets.push(self.line_string_counter);
         self.line_string_counter += 1;
 
-        self.types.push(MixedGeometryOrdering::LineString.into());
+        self.types.push(MixedGeometryOrdering::LineString.default_ordering());
         self.line_strings.push_line_string(value)
     }
 
@@ -215,7 +214,7 @@ impl<'a, O: Offset> MutableMixedGeometryArray<O> {
         self.multi_line_string_counter += 1;
 
         self.types
-            .push(MixedGeometryOrdering::MultiLineString.into());
+            .push(MixedGeometryOrdering::MultiLineString.default_ordering());
         self.multi_line_strings.push_line_string(value)
     }
 
@@ -229,7 +228,7 @@ impl<'a, O: Offset> MutableMixedGeometryArray<O> {
         self.offsets.push(self.polygon_counter);
         self.polygon_counter += 1;
 
-        self.types.push(MixedGeometryOrdering::Polygon.into());
+        self.types.push(MixedGeometryOrdering::Polygon.default_ordering());
         self.polygons.push_polygon(value)
     }
 
@@ -246,7 +245,7 @@ impl<'a, O: Offset> MutableMixedGeometryArray<O> {
         self.offsets.push(self.multi_polygon_counter);
         self.multi_polygon_counter += 1;
 
-        self.types.push(MixedGeometryOrdering::MultiPolygon.into());
+        self.types.push(MixedGeometryOrdering::MultiPolygon.default_ordering());
         self.multi_polygons.push_polygon(value)
     }
 
@@ -262,7 +261,7 @@ impl<'a, O: Offset> MutableMixedGeometryArray<O> {
         self.offsets.push(self.multi_point_counter);
         self.multi_point_counter += 1;
 
-        self.types.push(MixedGeometryOrdering::MultiPoint.into());
+        self.types.push(MixedGeometryOrdering::MultiPoint.default_ordering());
         self.multi_points.push_multi_point(value)
     }
 
@@ -279,7 +278,7 @@ impl<'a, O: Offset> MutableMixedGeometryArray<O> {
         self.multi_line_string_counter += 1;
 
         self.types
-            .push(MixedGeometryOrdering::MultiLineString.into());
+            .push(MixedGeometryOrdering::MultiLineString.default_ordering());
         self.multi_line_strings.push_multi_line_string(value)
     }
 
@@ -295,7 +294,7 @@ impl<'a, O: Offset> MutableMixedGeometryArray<O> {
         self.offsets.push(self.multi_polygon_counter);
         self.multi_polygon_counter += 1;
 
-        self.types.push(MixedGeometryOrdering::MultiPolygon.into());
+        self.types.push(MixedGeometryOrdering::MultiPolygon.default_ordering());
         self.multi_polygons.push_multi_polygon(value)
     }
 }

--- a/src/array/mod.rs
+++ b/src/array/mod.rs
@@ -7,6 +7,7 @@ pub use coord::{
 };
 pub use geometry::GeometryArray;
 pub use linestring::{LineStringArray, MutableLineStringArray};
+pub use mixed::MixedGeometryArray;
 pub use multilinestring::{MultiLineStringArray, MutableMultiLineStringArray};
 pub use multipoint::{MultiPointArray, MutableMultiPointArray};
 pub use multipolygon::{MultiPolygonArray, MutableMultiPolygonArray};

--- a/src/array/mod.rs
+++ b/src/array/mod.rs
@@ -18,6 +18,7 @@ pub mod binary;
 pub mod coord;
 pub mod geometry;
 pub mod linestring;
+pub mod mixed;
 pub mod multilinestring;
 pub mod multipoint;
 pub mod multipolygon;

--- a/src/array/mod.rs
+++ b/src/array/mod.rs
@@ -7,7 +7,7 @@ pub use coord::{
 };
 pub use geometry::GeometryArray;
 pub use linestring::{LineStringArray, MutableLineStringArray};
-pub use mixed::MixedGeometryArray;
+pub use mixed::{MixedGeometryArray, MutableMixedGeometryArray};
 pub use multilinestring::{MultiLineStringArray, MutableMultiLineStringArray};
 pub use multipoint::{MultiPointArray, MutableMultiPointArray};
 pub use multipolygon::{MultiPolygonArray, MutableMultiPolygonArray};

--- a/src/array/multilinestring/array.rs
+++ b/src/array/multilinestring/array.rs
@@ -479,6 +479,13 @@ impl TryFrom<MultiLineStringArray<i64>> for MultiLineStringArray<i32> {
     }
 }
 
+/// Default to an empty array
+impl<O: Offset> Default for MultiLineStringArray<O> {
+    fn default() -> Self {
+        MutableMultiLineStringArray::default().into()
+    }
+}
+
 #[cfg(test)]
 mod test {
     use crate::test::geoarrow_data::{

--- a/src/array/multipoint/array.rs
+++ b/src/array/multipoint/array.rs
@@ -402,6 +402,13 @@ impl TryFrom<MultiPointArray<i64>> for MultiPointArray<i32> {
     }
 }
 
+/// Default to an empty array
+impl<O: Offset> Default for MultiPointArray<O> {
+    fn default() -> Self {
+        MutableMultiPointArray::default().into()
+    }
+}
+
 #[cfg(test)]
 mod test {
     use super::*;

--- a/src/array/multipolygon/array.rs
+++ b/src/array/multipolygon/array.rs
@@ -46,8 +46,6 @@ pub(super) fn check<O: Offset>(
             "validity mask length must match the number of values".to_string(),
         ));
     }
-
-    dbg!(coords.len());
     if ring_offsets.last().to_usize() != coords.len() {
         return Err(GeoArrowError::General(
             "largest ring offset must match coords length".to_string(),

--- a/src/array/multipolygon/array.rs
+++ b/src/array/multipolygon/array.rs
@@ -510,6 +510,13 @@ impl TryFrom<MultiPolygonArray<i64>> for MultiPolygonArray<i32> {
     }
 }
 
+/// Default to an empty array
+impl<O: Offset> Default for MultiPolygonArray<O> {
+    fn default() -> Self {
+        MutableMultiPolygonArray::default().into()
+    }
+}
+
 #[cfg(test)]
 mod test {
     use super::*;

--- a/src/array/point/array.rs
+++ b/src/array/point/array.rs
@@ -305,6 +305,13 @@ impl<O: Offset> TryFrom<WKBArray<O>> for PointArray {
     }
 }
 
+/// Default to an empty array
+impl Default for PointArray {
+    fn default() -> Self {
+        MutablePointArray::default().into()
+    }
+}
+
 #[cfg(test)]
 mod test {
     use crate::test::geoarrow_data::{

--- a/src/array/polygon/array.rs
+++ b/src/array/polygon/array.rs
@@ -445,6 +445,13 @@ impl TryFrom<PolygonArray<i64>> for PolygonArray<i32> {
     }
 }
 
+/// Default to an empty array
+impl<O: Offset> Default for PolygonArray<O> {
+    fn default() -> Self {
+        MutablePolygonArray::default().into()
+    }
+}
+
 #[cfg(test)]
 mod test {
     use crate::test::geoarrow_data::{

--- a/src/scalar/geometry/geos.rs
+++ b/src/scalar/geometry/geos.rs
@@ -1,0 +1,28 @@
+use crate::error::{GeoArrowError, Result};
+use crate::scalar::Geometry;
+use arrow2::types::Offset;
+
+impl<'b, O: Offset> TryFrom<Geometry<'_, O>> for geos::Geometry<'b> {
+    type Error = GeoArrowError;
+
+    fn try_from(value: Geometry<'_, O>) -> Result<geos::Geometry<'b>> {
+        geos::Geometry::try_from(&value)
+    }
+}
+
+impl<'a, 'b, O: Offset> TryFrom<&'a Geometry<'_, O>> for geos::Geometry<'b> {
+    type Error = GeoArrowError;
+
+    fn try_from(value: &'a Geometry<'_, O>) -> Result<geos::Geometry<'b>> {
+        match value {
+            Geometry::Point(g) => g.try_into(),
+            Geometry::LineString(g) => g.try_into(),
+            Geometry::Polygon(g) => g.try_into(),
+            Geometry::MultiPoint(g) => g.try_into(),
+            Geometry::MultiLineString(g) => g.try_into(),
+            Geometry::MultiPolygon(g) => g.try_into(),
+            Geometry::WKB(g) => g.try_into(),
+            Geometry::Rect(g) => todo!(),
+        }
+    }
+}

--- a/src/scalar/geometry/geos.rs
+++ b/src/scalar/geometry/geos.rs
@@ -22,7 +22,7 @@ impl<'a, 'b, O: Offset> TryFrom<&'a Geometry<'_, O>> for geos::Geometry<'b> {
             Geometry::MultiLineString(g) => g.try_into(),
             Geometry::MultiPolygon(g) => g.try_into(),
             Geometry::WKB(g) => g.try_into(),
-            Geometry::Rect(g) => todo!(),
+            Geometry::Rect(_g) => todo!(),
         }
     }
 }

--- a/src/scalar/geometry/mod.rs
+++ b/src/scalar/geometry/mod.rs
@@ -1,3 +1,5 @@
+#[cfg(feature = "geos")]
+mod geos;
 mod scalar;
 
 pub use scalar::Geometry;


### PR DESCRIPTION
This is an implementation of an array of geometries of mixed type. It uses an equivalent storage to the `arrow2` `UnionArray`.

On top of this, we can implement (non-nested) geometry collections in the future, using a list of this mixed array. If we really want full simple features compliance, we could allow that `GeometryCollectionArray` to be a child of this `MixedGeometryArray`, enabling (in theory!) nested geometry collections.

### Todo:

- [x] How to ensure `O(1)` conversions to/from arrow2. In particular, where the order of the child arrays is arbitrary. But that's important for the semantic meaning of the `types` array
- [x] Flesh out conversions to and from `arrow2`. 