### PR TITLE
Remove `WKB` variant from GeometryArray and Geometry

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -316,7 +316,7 @@ dependencies = [
  "bitflags 1.3.2",
  "clap_derive",
  "clap_lex 0.2.4",
- "indexmap",
+ "indexmap 1.9.3",
  "once_cell",
  "strsim",
  "termcolor",
@@ -516,6 +516,12 @@ name = "either"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91"
+
+[[package]]
+name = "equivalent"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "errno"
@@ -731,6 +737,7 @@ dependencies = [
  "geos",
  "geozero",
  "itertools 0.11.0",
+ "num_enum",
  "rstar",
  "thiserror",
 ]
@@ -852,6 +859,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
+name = "hashbrown"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c6201b9ff9fd90a5a3bac2e56a830d0caa509576f0e503818ee82c181b3437a"
+
+[[package]]
 name = "heapless"
 version = "0.7.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -892,7 +905,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
  "autocfg",
- "hashbrown",
+ "hashbrown 0.12.3",
+]
+
+[[package]]
+name = "indexmap"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5477fe2230a79769d8dc68e0eabf5437907c0457a5614a9e8dddb67f65eb65d"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.14.0",
 ]
 
 [[package]]
@@ -1120,6 +1143,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_enum"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70bf6736f74634d299d00086f02986875b3c2d924781a6a2cb6c201e73da0ceb"
+dependencies = [
+ "num_enum_derive",
+]
+
+[[package]]
+name = "num_enum_derive"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56ea360eafe1022f7cc56cd7b869ed57330fb2453d0c7831d99b74c65d2f5597"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.22",
+]
+
+[[package]]
 name = "num_threads"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1227,6 +1271,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38f6d39893cca0701371e3c27294f09797214b86f1fb951b89ade8ec04e2abab"
 dependencies = [
  "plotters-backend",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f4c021e1093a56626774e81216a4ce732a735e5bad4868a03f3ed65ca0c3919"
+dependencies = [
+ "once_cell",
+ "toml_edit",
 ]
 
 [[package]]
@@ -1610,6 +1664,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_datetime"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cda73e2f1397b1262d6dfdcef8aafae14d1de7748d66822d3bfeeb6d03e5e4b"
+
+[[package]]
+name = "toml_edit"
+version = "0.19.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8123f27e969974a3dfba720fdb560be359f57b44302d280ba72e76a74480e8a"
+dependencies = [
+ "indexmap 2.0.0",
+ "toml_datetime",
+ "winnow",
+]
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1806,6 +1877,15 @@ name = "windows_x86_64_msvc"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
+
+[[package]]
+name = "winnow"
+version = "0.5.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5504cc7644f4b593cbc05c4a55bf9bd4e94b867c3c0bd440934174d50482427d"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "wkt"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ geodesy = { version = "0.10", optional = true }
 geos = { version = "8.3", features = ["v3_10_0", "geo"], optional = true }
 geozero = { version = "0.10", features = ["with-wkb"], optional = true }
 itertools = "0.11"
+num_enum = "0.7"
 # Note: geo has a hard dependency on rstar, so there's no point in feature flagging it
 rstar = { version = "0.11" }
 thiserror = "1"

--- a/js/Cargo.lock
+++ b/js/Cargo.lock
@@ -145,7 +145,7 @@ dependencies = [
  "bitflags",
  "clap_derive",
  "clap_lex",
- "indexmap",
+ "indexmap 1.9.3",
  "once_cell",
  "strsim",
  "termcolor",
@@ -244,6 +244,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a26ae43d7bcc3b814de94796a5e736d4029efb0ee900c12e2d54c993ad1a1e07"
 
 [[package]]
+name = "equivalent"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+
+[[package]]
 name = "ethnum"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -315,6 +321,7 @@ dependencies = [
  "geo",
  "geodesy",
  "itertools 0.11.0",
+ "num_enum",
  "rstar",
  "thiserror",
 ]
@@ -378,6 +385,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
+name = "hashbrown"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c6201b9ff9fd90a5a3bac2e56a830d0caa509576f0e503818ee82c181b3437a"
+
+[[package]]
 name = "heapless"
 version = "0.7.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -412,7 +425,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
  "autocfg",
- "hashbrown",
+ "hashbrown 0.12.3",
+]
+
+[[package]]
+name = "indexmap"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d5477fe2230a79769d8dc68e0eabf5437907c0457a5614a9e8dddb67f65eb65d"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.14.0",
 ]
 
 [[package]]
@@ -483,6 +506,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b06a4cde4c0f271a446782e3eff8de789548ce57dbc8eca9292c27f4a42004b4"
 
 [[package]]
+name = "memchr"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
+
+[[package]]
 name = "num-traits"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -490,6 +519,27 @@ checksum = "f30b0abd723be7e2ffca1272140fac1a2f084c77ec3e123c192b66af1ee9e6c2"
 dependencies = [
  "autocfg",
  "libm",
+]
+
+[[package]]
+name = "num_enum"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70bf6736f74634d299d00086f02986875b3c2d924781a6a2cb6c201e73da0ceb"
+dependencies = [
+ "num_enum_derive",
+]
+
+[[package]]
+name = "num_enum_derive"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56ea360eafe1022f7cc56cd7b869ed57330fb2453d0c7831d99b74c65d2f5597"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.27",
 ]
 
 [[package]]
@@ -512,6 +562,16 @@ name = "os_str_bytes"
 version = "6.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d5d9eb14b174ee9aa2ef96dc2b94637a2d4b6e7cb873c7e171f0c20c6cf3eac"
+
+[[package]]
+name = "proc-macro-crate"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f4c021e1093a56626774e81216a4ce732a735e5bad4868a03f3ed65ca0c3919"
+dependencies = [
+ "once_cell",
+ "toml_edit",
+]
 
 [[package]]
 name = "proc-macro-error"
@@ -772,6 +832,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_datetime"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cda73e2f1397b1262d6dfdcef8aafae14d1de7748d66822d3bfeeb6d03e5e4b"
+
+[[package]]
+name = "toml_edit"
+version = "0.19.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8123f27e969974a3dfba720fdb560be359f57b44302d280ba72e76a74480e8a"
+dependencies = [
+ "indexmap 2.0.0",
+ "toml_datetime",
+ "winnow",
+]
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -929,3 +1006,12 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "winnow"
+version = "0.5.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5504cc7644f4b593cbc05c4a55bf9bd4e94b867c3c0bd440934174d50482427d"
+dependencies = [
+ "memchr",
+]

--- a/js/src/array/geometry.rs
+++ b/js/src/array/geometry.rs
@@ -66,7 +66,6 @@ impl GeometryArray {
             geoarrow::array::GeometryArray::MultiPoint(_) => GeometryType::MultiPoint,
             geoarrow::array::GeometryArray::MultiLineString(_) => GeometryType::MultiLineString,
             geoarrow::array::GeometryArray::MultiPolygon(_) => GeometryType::MultiPolygon,
-            geoarrow::array::GeometryArray::WKB(_) => unimplemented!(),
             geoarrow::array::GeometryArray::Rect(_) => unimplemented!(),
         }
     }

--- a/src/algorithm/geo/bounding_rect.rs
+++ b/src/algorithm/geo/bounding_rect.rs
@@ -1,7 +1,4 @@
-use crate::array::{
-    GeometryArray, LineStringArray, MultiLineStringArray, MultiPointArray, MultiPolygonArray,
-    PointArray, PolygonArray, WKBArray,
-};
+use crate::array::*;
 use arrow2::types::Offset;
 use geo::algorithm::bounding_rect::BoundingRect as GeoBoundingRect;
 use geo::Polygon;

--- a/src/algorithm/geo/dimensions.rs
+++ b/src/algorithm/geo/dimensions.rs
@@ -63,7 +63,6 @@ iter_geo_impl!(WKBArray<O>);
 impl<O: Offset> HasDimensions for GeometryArray<O> {
     fn is_empty(&self) -> BooleanArray {
         match self {
-            GeometryArray::WKB(arr) => HasDimensions::is_empty(arr),
             GeometryArray::Point(arr) => HasDimensions::is_empty(arr),
             GeometryArray::LineString(arr) => HasDimensions::is_empty(arr),
             GeometryArray::Polygon(arr) => HasDimensions::is_empty(arr),

--- a/src/algorithm/geo/utils.rs
+++ b/src/algorithm/geo/utils.rs
@@ -30,7 +30,6 @@ macro_rules! __geometry_array_delegate_impl_helper {
                 $(#[$outer])*
                 fn $func_name(&$($self_life)? self, $($arg_name: $arg_type),*) -> $return {
                     match self {
-                        $enum::WKB(g) => g.$func_name($($arg_name),*).into(),
                         $enum::Point(g) => g.$func_name($($arg_name),*).into(),
                         // $enum::Line(g) =>  g.$func_name($($arg_name),*).into(),
                         $enum::LineString(g) => g.$func_name($($arg_name),*).into(),

--- a/src/algorithm/geodesy/reproject.rs
+++ b/src/algorithm/geodesy/reproject.rs
@@ -95,9 +95,6 @@ pub fn reproject<O: Offset>(
     direction: Direction,
 ) -> Result<GeometryArray<O>> {
     match array {
-        GeometryArray::WKB(_arr) => {
-            unimplemented!()
-        }
         GeometryArray::Point(arr) => {
             let new_coords = reproject_coords(&arr.coords, definition, direction)?;
             Ok(GeometryArray::Point(arr.clone().with_coords(new_coords)))

--- a/src/algorithm/native/mod.rs
+++ b/src/algorithm/native/mod.rs
@@ -1,2 +1,3 @@
 pub(crate) mod bounding_rect;
 pub mod eq;
+pub mod type_id;

--- a/src/algorithm/native/type_id.rs
+++ b/src/algorithm/native/type_id.rs
@@ -1,0 +1,158 @@
+use crate::array::*;
+use crate::io::native::wkb::WKBGeometryType;
+use crate::GeometryArrayTrait;
+use arrow2::array::{MutablePrimitiveArray, PrimitiveArray};
+use arrow2::datatypes::DataType;
+use arrow2::types::Offset;
+use std::collections::HashSet;
+
+/// Calculation of the geometry types within a GeometryArray
+pub trait TypeIds {
+    /// Return the geometry types stored in this array
+    ///
+    /// The integer values of this return type match that of GEOS and Shapely:
+    ///
+    /// - None (missing) is -1
+    /// - POINT is 0
+    /// - LINESTRING is 1
+    /// - LINEARRING is 2
+    /// - POLYGON is 3
+    /// - MULTIPOINT is 4
+    /// - MULTILINESTRING is 5
+    /// - MULTIPOLYGON is 6
+    /// - GEOMETRYCOLLECTION is 7
+    fn get_type_ids(&self) -> PrimitiveArray<i8>;
+
+    /// Return the unique geometry types stored in this array
+    ///
+    /// The integer values of this return type match that of GEOS and Shapely:
+    ///
+    /// - None (missing) is -1
+    /// - POINT is 0
+    /// - LINESTRING is 1
+    /// - LINEARRING is 2
+    /// - POLYGON is 3
+    /// - MULTIPOINT is 4
+    /// - MULTILINESTRING is 5
+    /// - MULTIPOLYGON is 6
+    /// - GEOMETRYCOLLECTION is 7
+    fn get_unique_type_ids(&self) -> HashSet<i8>;
+}
+
+impl TypeIds for PointArray {
+    fn get_type_ids(&self) -> PrimitiveArray<i8> {
+        let values = vec![0i8; self.len()];
+        PrimitiveArray::new(DataType::Int8, values.into(), self.validity().cloned())
+    }
+
+    fn get_unique_type_ids(&self) -> HashSet<i8> {
+        let mut values = HashSet::with_capacity(1);
+        values.insert(0);
+        values
+    }
+}
+
+macro_rules! constant_impl {
+    ($type:ty, $value:expr) => {
+        impl<O: Offset> TypeIds for $type {
+            fn get_type_ids(&self) -> PrimitiveArray<i8> {
+                let values = vec![$value; self.len()];
+                PrimitiveArray::new(DataType::Int8, values.into(), self.validity().cloned())
+            }
+
+            fn get_unique_type_ids(&self) -> HashSet<i8> {
+                let mut values = HashSet::with_capacity(1);
+                values.insert($value);
+                values
+            }
+        }
+    };
+}
+
+constant_impl!(LineStringArray<O>, 1);
+constant_impl!(PolygonArray<O>, 3);
+constant_impl!(MultiPointArray<O>, 4);
+constant_impl!(MultiLineStringArray<O>, 5);
+constant_impl!(MultiPolygonArray<O>, 6);
+
+impl<O: Offset> TypeIds for MixedGeometryArray<O> {
+    fn get_type_ids(&self) -> PrimitiveArray<i8> {
+        use crate::scalar::Geometry::*;
+
+        let mut output_array = MutablePrimitiveArray::<i8>::with_capacity(self.len());
+        self.iter().for_each(|maybe_g| {
+            output_array.push(maybe_g.map(|g| match g {
+                Point(_) => 0,
+                LineString(_) => 1,
+                Polygon(_) => 3,
+                Rect(_) => 3,
+                MultiPoint(_) => 4,
+                MultiLineString(_) => 5,
+                MultiPolygon(_) => 6,
+            }))
+        });
+        output_array.into()
+    }
+
+    fn get_unique_type_ids(&self) -> HashSet<i8> {
+        use crate::scalar::Geometry::*;
+
+        let mut values = HashSet::new();
+        self.iter().flatten().for_each(|g| {
+            let type_id = match g {
+                Point(_) => 0,
+                LineString(_) => 1,
+                Polygon(_) => 3,
+                Rect(_) => 3,
+                MultiPoint(_) => 4,
+                MultiLineString(_) => 5,
+                MultiPolygon(_) => 6,
+            };
+            values.insert(type_id);
+        });
+
+        values
+    }
+}
+
+impl<O: Offset> TypeIds for WKBArray<O> {
+    fn get_type_ids(&self) -> PrimitiveArray<i8> {
+        use WKBGeometryType::*;
+
+        let mut output_array = MutablePrimitiveArray::<i8>::with_capacity(self.len());
+
+        self.iter().for_each(|maybe_wkb| {
+            output_array.push(maybe_wkb.map(|wkb| match wkb.get_wkb_geometry_type() {
+                Point => 0,
+                LineString => 1,
+                Polygon => 3,
+                MultiPoint => 4,
+                MultiLineString => 5,
+                MultiPolygon => 6,
+                GeometryCollection => 7,
+            }))
+        });
+
+        output_array.into()
+    }
+
+    fn get_unique_type_ids(&self) -> HashSet<i8> {
+        use WKBGeometryType::*;
+
+        let mut values = HashSet::new();
+        self.iter().flatten().for_each(|wkb| {
+            let type_id = match wkb.get_wkb_geometry_type() {
+                Point => 0,
+                LineString => 1,
+                Polygon => 3,
+                MultiPoint => 4,
+                MultiLineString => 5,
+                MultiPolygon => 6,
+                GeometryCollection => 7,
+            };
+            values.insert(type_id);
+        });
+
+        values
+    }
+}

--- a/src/io/geos/scalar/geometry.rs
+++ b/src/io/geos/scalar/geometry.rs
@@ -21,7 +21,6 @@ impl<'a, 'b, O: Offset> TryFrom<&'a Geometry<'_, O>> for geos::Geometry<'b> {
             Geometry::MultiPoint(g) => g.try_into(),
             Geometry::MultiLineString(g) => g.try_into(),
             Geometry::MultiPolygon(g) => g.try_into(),
-            Geometry::WKB(g) => g.try_into(),
             Geometry::Rect(_g) => todo!(),
         }
     }

--- a/src/io/native/wkb/mod.rs
+++ b/src/io/native/wkb/mod.rs
@@ -17,3 +17,15 @@ pub mod multipoint;
 pub mod multipolygon;
 pub mod point;
 pub mod polygon;
+pub mod r#type;
+
+pub use linestring::WKBLineString;
+pub use maybe_multi_line_string::WKBMaybeMultiLineString;
+pub use maybe_multi_point::WKBMaybeMultiPoint;
+pub use maybe_multipolygon::WKBMaybeMultiPolygon;
+pub use multilinestring::WKBMultiLineString;
+pub use multipoint::WKBMultiPoint;
+pub use multipolygon::WKBMultiPolygon;
+pub use point::WKBPoint;
+pub use polygon::WKBPolygon;
+pub use r#type::WKBGeometryType;

--- a/src/io/native/wkb/type.rs
+++ b/src/io/native/wkb/type.rs
@@ -1,0 +1,15 @@
+#![allow(non_upper_case_globals)]
+
+use num_enum::TryFromPrimitive;
+
+#[derive(Debug, Eq, PartialEq, TryFromPrimitive)]
+#[repr(u32)]
+pub enum WKBGeometryType {
+    Point = 1,
+    LineString = 2,
+    Polygon = 3,
+    MultiPoint = 4,
+    MultiLineString = 5,
+    MultiPolygon = 6,
+    GeometryCollection = 7,
+}

--- a/src/scalar/geometry/scalar.rs
+++ b/src/scalar/geometry/scalar.rs
@@ -4,6 +4,9 @@ use crate::trait_::GeometryScalarTrait;
 use arrow2::types::Offset;
 use rstar::{RTreeObject, AABB};
 
+/// A Geometry is an enum over the various underlying _zero copy_ GeoArrow scalar types.
+///
+/// Notably this does _not_ include [`WKB`] as a variant, because that is not zero-copy to parse.
 #[derive(Debug, PartialEq)]
 pub enum Geometry<'a, O: Offset> {
     Point(crate::scalar::Point<'a>),
@@ -12,7 +15,6 @@ pub enum Geometry<'a, O: Offset> {
     MultiPoint(crate::scalar::MultiPoint<'a, O>),
     MultiLineString(crate::scalar::MultiLineString<'a, O>),
     MultiPolygon(crate::scalar::MultiPolygon<'a, O>),
-    WKB(crate::scalar::WKB<'a, O>),
     Rect(crate::scalar::Rect<'a>),
 }
 
@@ -27,7 +29,6 @@ impl<'a, O: Offset> GeometryScalarTrait<'a> for Geometry<'a, O> {
             Geometry::MultiPoint(g) => geo::Geometry::MultiPoint(g.into()),
             Geometry::MultiLineString(g) => geo::Geometry::MultiLineString(g.into()),
             Geometry::MultiPolygon(g) => geo::Geometry::MultiPolygon(g.into()),
-            Geometry::WKB(g) => g.into(),
             Geometry::Rect(g) => geo::Geometry::Rect(g.into()),
         }
     }
@@ -84,7 +85,6 @@ impl<O: Offset> RTreeObject for Geometry<'_, O> {
             Geometry::MultiPoint(geom) => geom.envelope(),
             Geometry::MultiLineString(geom) => geom.envelope(),
             Geometry::MultiPolygon(geom) => geom.envelope(),
-            Geometry::WKB(geom) => geom.envelope(),
             Geometry::Rect(geom) => geom.envelope(),
         }
     }
@@ -99,7 +99,6 @@ impl<O: Offset> From<Geometry<'_, O>> for geo::Geometry {
             Geometry::MultiPoint(geom) => geom.into(),
             Geometry::MultiLineString(geom) => geom.into(),
             Geometry::MultiPolygon(geom) => geom.into(),
-            Geometry::WKB(geom) => geom.into(),
             Geometry::Rect(geom) => geom.into(),
         }
     }

--- a/src/scalar/geometry/scalar.rs
+++ b/src/scalar/geometry/scalar.rs
@@ -69,7 +69,6 @@ impl<'a, O: Offset> GeometryTrait<'a> for Geometry<'a, O> {
             Geometry::MultiPolygon(p) => GeometryType::MultiPolygon(p),
             // Geometry::GeometryCollection(p) => GeometryType::GeometryCollection(p),
             Geometry::Rect(p) => GeometryType::Rect(p),
-            _ => todo!(),
         }
     }
 }


### PR DESCRIPTION
### Change list

- Remove `WKB` variant from `GeometryArray` and `Geometry`
- Add `TypeIds` trait to get the geometry types from an array of geometries.
- Implement parsing from `WKBArray` to an arrow-native `GeometryArray`

Closes https://github.com/kylebarron/geoarrow-rs/issues/153, closes https://github.com/kylebarron/geoarrow-rs/issues/87