### PR TITLE
Implement WKB writing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@ target/
 
 # MSVC Windows builds of rustc generate these, which store debugging information
 *.pdb
+
+*.fgb
+*.parquet

--- a/src/array/binary/mutable.rs
+++ b/src/array/binary/mutable.rs
@@ -1,3 +1,15 @@
+use crate::geo_traits::{
+    LineStringTrait, MultiLineStringTrait, MultiPointTrait, MultiPolygonTrait, PointTrait,
+    PolygonTrait,
+};
+use crate::io::wkb::writer::linestring::{line_string_wkb_size, write_line_string_as_wkb};
+use crate::io::wkb::writer::multilinestring::{
+    multi_line_string_wkb_size, write_multi_line_string_as_wkb,
+};
+use crate::io::wkb::writer::multipoint::{multi_point_wkb_size, write_multi_point_as_wkb};
+use crate::io::wkb::writer::multipolygon::{multi_polygon_wkb_size, write_multi_polygon_as_wkb};
+use crate::io::wkb::writer::point::{write_point_as_wkb, POINT_WKB_SIZE};
+use crate::io::wkb::writer::polygon::{polygon_wkb_size, write_polygon_as_wkb};
 use crate::trait_::MutableGeometryArray;
 use crate::GeometryArrayTrait;
 use arrow2::array::{Array, MutableArray, MutableBinaryArray};
@@ -38,6 +50,84 @@ impl<O: Offset> MutableWKBArray<O> {
     /// This does not allocate the validity.
     pub fn with_capacities(capacity: usize, values: usize) -> Self {
         Self(MutableBinaryArray::<O>::with_capacities(capacity, values))
+    }
+
+    /// Push a Point onto the end of this array
+    ///
+    /// ## Performance
+    ///
+    /// It is expected to be considerably faster if you convert whole geometry arrays at a time.
+    /// E.g. using the `From` implementation from PointArray.
+    pub fn push_point(&mut self, geom: impl PointTrait<T = f64>) {
+        // TODO: figure out how to write directly to the underlying vec without a copy
+        let mut buf = Vec::with_capacity(POINT_WKB_SIZE);
+        write_point_as_wkb(&mut buf, geom).unwrap();
+        self.0.push(Some(&buf))
+    }
+
+    /// Push a LineString onto the end of this array
+    ///
+    /// ## Performance
+    ///
+    /// It is expected to be considerably faster if you convert whole geometry arrays at a time.
+    /// E.g. using the `From` implementation from LineStringArray.
+    pub fn push_line_string<'a>(&mut self, geom: impl LineStringTrait<'a, T = f64>) {
+        // TODO: figure out how to write directly to the underlying vec without a copy
+        let mut buf = Vec::with_capacity(line_string_wkb_size(&geom));
+        write_line_string_as_wkb(&mut buf, geom).unwrap();
+        self.0.push(Some(&buf))
+    }
+
+    /// Push a Polygon onto the end of this array
+    ///
+    /// ## Performance
+    ///
+    /// It is expected to be considerably faster if you convert whole geometry arrays at a time.
+    /// E.g. using the `From` implementation from PolygonArray.
+    pub fn push_polygon<'a>(&mut self, geom: impl PolygonTrait<'a, T = f64>) {
+        // TODO: figure out how to write directly to the underlying vec without a copy
+        let mut buf = Vec::with_capacity(polygon_wkb_size(&geom));
+        write_polygon_as_wkb(&mut buf, geom).unwrap();
+        self.0.push(Some(&buf))
+    }
+
+    /// Push a MultiPoint onto the end of this array
+    ///
+    /// ## Performance
+    ///
+    /// It is expected to be considerably faster if you convert whole geometry arrays at a time.
+    /// E.g. using the `From` implementation from MultiPointArray.
+    pub fn push_multi_point<'a>(&mut self, geom: impl MultiPointTrait<'a, T = f64>) {
+        // TODO: figure out how to write directly to the underlying vec without a copy
+        let mut buf = Vec::with_capacity(multi_point_wkb_size(&geom));
+        write_multi_point_as_wkb(&mut buf, geom).unwrap();
+        self.0.push(Some(&buf))
+    }
+
+    /// Push a MultiLineString onto the end of this array
+    ///
+    /// ## Performance
+    ///
+    /// It is expected to be considerably faster if you convert whole geometry arrays at a time.
+    /// E.g. using the `From` implementation from MultiLineStringArray.
+    pub fn push_multi_line_string<'a>(&mut self, geom: impl MultiLineStringTrait<'a, T = f64>) {
+        // TODO: figure out how to write directly to the underlying vec without a copy
+        let mut buf = Vec::with_capacity(multi_line_string_wkb_size(&geom));
+        write_multi_line_string_as_wkb(&mut buf, geom).unwrap();
+        self.0.push(Some(&buf))
+    }
+
+    /// Push a MultiPolygon onto the end of this array
+    ///
+    /// ## Performance
+    ///
+    /// It is expected to be considerably faster if you convert whole geometry arrays at a time.
+    /// E.g. using the `From` implementation from MultiPolygonArray.
+    pub fn push_multi_polygon<'a>(&mut self, geom: impl MultiPolygonTrait<'a, T = f64>) {
+        // TODO: figure out how to write directly to the underlying vec without a copy
+        let mut buf = Vec::with_capacity(multi_polygon_wkb_size(&geom));
+        write_multi_polygon_as_wkb(&mut buf, geom).unwrap();
+        self.0.push(Some(&buf))
     }
 }
 

--- a/src/io/wkb/mod.rs
+++ b/src/io/wkb/mod.rs
@@ -1,1 +1,2 @@
 pub mod reader;
+pub mod writer;

--- a/src/io/wkb/reader/geometry.rs
+++ b/src/io/wkb/reader/geometry.rs
@@ -67,6 +67,16 @@ impl From<u8> for Endianness {
     }
 }
 
+impl From<Endianness> for u8 {
+    fn from(value: Endianness) -> Self {
+        use Endianness::*;
+        match value {
+            BigEndian => 0,
+            LittleEndian => 1,
+        }
+    }
+}
+
 pub enum WKBGeometry<'a> {
     Point(WKBPoint<'a>),
     LineString(WKBLineString<'a>),

--- a/src/io/wkb/writer/linestring.rs
+++ b/src/io/wkb/writer/linestring.rs
@@ -11,7 +11,7 @@ use byteorder::{LittleEndian, WriteBytesExt};
 use std::io::{Cursor, Write};
 
 /// The byte length of a WKBLineString
-pub fn linestring_wkb_size<'a>(geom: impl LineStringTrait<'a>) -> usize {
+pub fn line_string_wkb_size<'a>(geom: impl LineStringTrait<'a>) -> usize {
     1 + 4 + 4 + (geom.num_coords() * 16)
 }
 
@@ -47,7 +47,7 @@ impl<A: Offset, B: Offset> From<&LineStringArray<A>> for WKBArray<B> {
         // First pass: calculate binary array offsets
         for maybe_geom in value.iter() {
             if let Some(geom) = maybe_geom {
-                offsets.try_push_usize(linestring_wkb_size(geom)).unwrap();
+                offsets.try_push_usize(line_string_wkb_size(geom)).unwrap();
             } else {
                 offsets.extend_constant(1);
             }

--- a/src/io/wkb/writer/linestring.rs
+++ b/src/io/wkb/writer/linestring.rs
@@ -11,7 +11,7 @@ use byteorder::{LittleEndian, WriteBytesExt};
 use std::io::{Cursor, Write};
 
 /// The byte length of a WKBLineString
-pub fn line_string_wkb_size<'a>(geom: impl LineStringTrait<'a>) -> usize {
+pub fn line_string_wkb_size<'a>(geom: &impl LineStringTrait<'a>) -> usize {
     1 + 4 + 4 + (geom.num_coords() * 16)
 }
 
@@ -47,7 +47,7 @@ impl<A: Offset, B: Offset> From<&LineStringArray<A>> for WKBArray<B> {
         // First pass: calculate binary array offsets
         for maybe_geom in value.iter() {
             if let Some(geom) = maybe_geom {
-                offsets.try_push_usize(line_string_wkb_size(geom)).unwrap();
+                offsets.try_push_usize(line_string_wkb_size(&geom)).unwrap();
             } else {
                 offsets.extend_constant(1);
             }

--- a/src/io/wkb/writer/linestring.rs
+++ b/src/io/wkb/writer/linestring.rs
@@ -1,0 +1,96 @@
+use crate::array::{LineStringArray, WKBArray};
+use crate::error::Result;
+use crate::geo_traits::{CoordTrait, LineStringTrait};
+use crate::io::wkb::reader::geometry::Endianness;
+use crate::trait_::GeometryArrayTrait;
+use arrow2::array::BinaryArray;
+use arrow2::datatypes::DataType;
+use arrow2::offset::Offsets;
+use arrow2::types::Offset;
+use byteorder::{LittleEndian, WriteBytesExt};
+use std::io::{Cursor, Write};
+
+/// The byte length of a WKBLineString
+pub fn linestring_wkb_size<'a>(geom: impl LineStringTrait<'a>) -> usize {
+    1 + 4 + 4 + (geom.num_coords() * 16)
+}
+
+/// Write a Point geometry to a Writer encoded as WKB
+pub fn write_line_string_as_wkb<'a, W: Write>(
+    mut writer: W,
+    geom: impl LineStringTrait<'a, T = f64>,
+) -> Result<()> {
+    // Byte order
+    writer.write_u8(Endianness::LittleEndian.into()).unwrap();
+
+    // wkbType = 2
+    writer.write_u32::<LittleEndian>(2).unwrap();
+
+    // numPoints
+    writer
+        .write_u32::<LittleEndian>(geom.num_coords().try_into().unwrap())
+        .unwrap();
+
+    for coord_idx in 0..geom.num_coords() {
+        let coord = geom.coord(coord_idx).unwrap();
+        writer.write_f64::<LittleEndian>(coord.x()).unwrap();
+        writer.write_f64::<LittleEndian>(coord.y()).unwrap();
+    }
+
+    Ok(())
+}
+
+// TODO: decouple these two generics?
+impl<O: Offset> From<&LineStringArray<O>> for WKBArray<O> {
+    fn from(value: &LineStringArray<O>) -> Self {
+        let mut offsets: Offsets<O> = Offsets::with_capacity(value.len());
+
+        // First pass: calculate binary array offsets
+        for maybe_geom in value.iter() {
+            if let Some(geom) = maybe_geom {
+                offsets.try_push_usize(linestring_wkb_size(geom)).unwrap();
+            } else {
+                offsets.extend_constant(1);
+            }
+        }
+
+        let values = {
+            let values = Vec::with_capacity(offsets.last().to_usize());
+            let mut writer = Cursor::new(values);
+
+            for geom in value.iter().flatten() {
+                write_line_string_as_wkb(&mut writer, geom).unwrap();
+            }
+
+            writer.into_inner()
+        };
+
+        let data_type = match O::IS_LARGE {
+            true => DataType::LargeBinary,
+            false => DataType::Binary,
+        };
+
+        let binary_arr = BinaryArray::new(
+            data_type,
+            offsets.into(),
+            values.into(),
+            value.validity().cloned(),
+        );
+        WKBArray::new(binary_arr)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::test::linestring::{ls0, ls1};
+
+    #[test]
+    fn round_trip() {
+        let orig_arr: LineStringArray<i32> = vec![Some(ls0()), Some(ls1()), None].into();
+        let wkb_arr: WKBArray<i32> = (&orig_arr).into();
+        let new_arr: LineStringArray<i32> = wkb_arr.try_into().unwrap();
+
+        assert_eq!(orig_arr, new_arr);
+    }
+}

--- a/src/io/wkb/writer/linestring.rs
+++ b/src/io/wkb/writer/linestring.rs
@@ -15,7 +15,7 @@ pub fn line_string_wkb_size<'a>(geom: impl LineStringTrait<'a>) -> usize {
     1 + 4 + 4 + (geom.num_coords() * 16)
 }
 
-/// Write a Point geometry to a Writer encoded as WKB
+/// Write a LineString geometry to a Writer encoded as WKB
 pub fn write_line_string_as_wkb<'a, W: Write>(
     mut writer: W,
     geom: impl LineStringTrait<'a, T = f64>,

--- a/src/io/wkb/writer/linestring.rs
+++ b/src/io/wkb/writer/linestring.rs
@@ -40,10 +40,9 @@ pub fn write_line_string_as_wkb<'a, W: Write>(
     Ok(())
 }
 
-// TODO: decouple these two generics?
-impl<O: Offset> From<&LineStringArray<O>> for WKBArray<O> {
-    fn from(value: &LineStringArray<O>) -> Self {
-        let mut offsets: Offsets<O> = Offsets::with_capacity(value.len());
+impl<A: Offset, B: Offset> From<&LineStringArray<A>> for WKBArray<B> {
+    fn from(value: &LineStringArray<A>) -> Self {
+        let mut offsets: Offsets<B> = Offsets::with_capacity(value.len());
 
         // First pass: calculate binary array offsets
         for maybe_geom in value.iter() {
@@ -65,7 +64,7 @@ impl<O: Offset> From<&LineStringArray<O>> for WKBArray<O> {
             writer.into_inner()
         };
 
-        let data_type = match O::IS_LARGE {
+        let data_type = match B::IS_LARGE {
             true => DataType::LargeBinary,
             false => DataType::Binary,
         };
@@ -93,4 +92,13 @@ mod test {
 
         assert_eq!(orig_arr, new_arr);
     }
+
+    // // TODO: parsing WKBArray<i64> into LineStringArray<i32> not yet implemented
+    // fn round_trip_to_i64() {
+    //     let orig_arr: LineStringArray<i32> = vec![Some(ls0()), Some(ls1()), None].into();
+    //     let wkb_arr: WKBArray<i64> = (&orig_arr).into();
+    //     let new_arr: LineStringArray<i32> = wkb_arr.try_into().unwrap();
+
+    //     assert_eq!(orig_arr, new_arr);
+    // }
 }

--- a/src/io/wkb/writer/mod.rs
+++ b/src/io/wkb/writer/mod.rs
@@ -1,0 +1,6 @@
+pub mod linestring;
+pub mod multilinestring;
+pub mod multipoint;
+pub mod multipolygon;
+pub mod point;
+pub mod polygon;

--- a/src/io/wkb/writer/multilinestring.rs
+++ b/src/io/wkb/writer/multilinestring.rs
@@ -1,0 +1,103 @@
+use crate::array::{MultiLineStringArray, WKBArray};
+use crate::error::Result;
+use crate::geo_traits::MultiLineStringTrait;
+use crate::io::wkb::reader::geometry::Endianness;
+use crate::io::wkb::writer::linestring::{line_string_wkb_size, write_line_string_as_wkb};
+use crate::trait_::GeometryArrayTrait;
+use arrow2::array::BinaryArray;
+use arrow2::datatypes::DataType;
+use arrow2::offset::Offsets;
+use arrow2::types::Offset;
+use byteorder::{LittleEndian, WriteBytesExt};
+use std::io::{Cursor, Write};
+
+/// The byte length of a WKBMultiLineString
+pub fn multi_line_string_wkb_size<'a>(geom: impl MultiLineStringTrait<'a>) -> usize {
+    let mut sum = 1 + 4 + 4;
+    for line_string_idx in 0..geom.num_lines() {
+        let line_string = geom.line(line_string_idx).unwrap();
+        sum += line_string_wkb_size(line_string);
+    }
+
+    sum
+}
+
+/// Write a MultiLineString geometry to a Writer encoded as WKB
+pub fn write_multi_line_string_as_wkb<'a, W: Write>(
+    mut writer: W,
+    geom: impl MultiLineStringTrait<'a, T = f64>,
+) -> Result<()> {
+    // Byte order
+    writer.write_u8(Endianness::LittleEndian.into()).unwrap();
+
+    // wkbType = 5
+    writer.write_u32::<LittleEndian>(5).unwrap();
+
+    // numPoints
+    writer
+        .write_u32::<LittleEndian>(geom.num_lines().try_into().unwrap())
+        .unwrap();
+
+    for line_string_idx in 0..geom.num_lines() {
+        let line_string = geom.line(line_string_idx).unwrap();
+        write_line_string_as_wkb(&mut writer, line_string).unwrap();
+    }
+
+    Ok(())
+}
+
+impl<A: Offset, B: Offset> From<&MultiLineStringArray<A>> for WKBArray<B> {
+    fn from(value: &MultiLineStringArray<A>) -> Self {
+        let mut offsets: Offsets<B> = Offsets::with_capacity(value.len());
+
+        // First pass: calculate binary array offsets
+        for maybe_geom in value.iter() {
+            if let Some(geom) = maybe_geom {
+                offsets
+                    .try_push_usize(multi_line_string_wkb_size(geom))
+                    .unwrap();
+            } else {
+                offsets.extend_constant(1);
+            }
+        }
+
+        let values = {
+            let values = Vec::with_capacity(offsets.last().to_usize());
+            let mut writer = Cursor::new(values);
+
+            for geom in value.iter().flatten() {
+                write_multi_line_string_as_wkb(&mut writer, geom).unwrap();
+            }
+
+            writer.into_inner()
+        };
+
+        let data_type = match B::IS_LARGE {
+            true => DataType::LargeBinary,
+            false => DataType::Binary,
+        };
+
+        let binary_arr = BinaryArray::new(
+            data_type,
+            offsets.into(),
+            values.into(),
+            value.validity().cloned(),
+        );
+        WKBArray::new(binary_arr)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::test::multilinestring::{ml0, ml1};
+
+    #[test]
+    fn round_trip() {
+        let orig_arr: MultiLineStringArray<i32> = vec![Some(ml0()), Some(ml1()), None].into();
+        let wkb_arr: WKBArray<i32> = (&orig_arr).into();
+        let new_arr: MultiLineStringArray<i32> = wkb_arr.try_into().unwrap();
+
+        assert_eq!(orig_arr, new_arr);
+    }
+}

--- a/src/io/wkb/writer/multilinestring.rs
+++ b/src/io/wkb/writer/multilinestring.rs
@@ -12,11 +12,11 @@ use byteorder::{LittleEndian, WriteBytesExt};
 use std::io::{Cursor, Write};
 
 /// The byte length of a WKBMultiLineString
-pub fn multi_line_string_wkb_size<'a>(geom: impl MultiLineStringTrait<'a>) -> usize {
+pub fn multi_line_string_wkb_size<'a>(geom: &impl MultiLineStringTrait<'a>) -> usize {
     let mut sum = 1 + 4 + 4;
     for line_string_idx in 0..geom.num_lines() {
         let line_string = geom.line(line_string_idx).unwrap();
-        sum += line_string_wkb_size(line_string);
+        sum += line_string_wkb_size(&line_string);
     }
 
     sum
@@ -54,7 +54,7 @@ impl<A: Offset, B: Offset> From<&MultiLineStringArray<A>> for WKBArray<B> {
         for maybe_geom in value.iter() {
             if let Some(geom) = maybe_geom {
                 offsets
-                    .try_push_usize(multi_line_string_wkb_size(geom))
+                    .try_push_usize(multi_line_string_wkb_size(&geom))
                     .unwrap();
             } else {
                 offsets.extend_constant(1);

--- a/src/io/wkb/writer/multipoint.rs
+++ b/src/io/wkb/writer/multipoint.rs
@@ -1,0 +1,95 @@
+use crate::array::{MultiPointArray, WKBArray};
+use crate::error::Result;
+use crate::geo_traits::MultiPointTrait;
+use crate::io::wkb::reader::geometry::Endianness;
+use crate::io::wkb::writer::point::{write_point_as_wkb, POINT_WKB_SIZE};
+use crate::trait_::GeometryArrayTrait;
+use arrow2::array::BinaryArray;
+use arrow2::datatypes::DataType;
+use arrow2::offset::Offsets;
+use arrow2::types::Offset;
+use byteorder::{LittleEndian, WriteBytesExt};
+use std::io::{Cursor, Write};
+
+/// The byte length of a WKBMultiPoint
+pub fn multi_point_wkb_size<'a>(geom: impl MultiPointTrait<'a>) -> usize {
+    1 + 4 + 4 + (geom.num_points() * POINT_WKB_SIZE)
+}
+
+/// Write a Point geometry to a Writer encoded as WKB
+pub fn write_line_string_as_wkb<'a, W: Write>(
+    mut writer: W,
+    geom: impl MultiPointTrait<'a, T = f64>,
+) -> Result<()> {
+    // Byte order
+    writer.write_u8(Endianness::LittleEndian.into()).unwrap();
+
+    // wkbType = 4
+    writer.write_u32::<LittleEndian>(4).unwrap();
+
+    // numPoints
+    writer
+        .write_u32::<LittleEndian>(geom.num_points().try_into().unwrap())
+        .unwrap();
+
+    for point_idx in 0..geom.num_points() {
+        let point = geom.point(point_idx).unwrap();
+        write_point_as_wkb(&mut writer, point).unwrap();
+    }
+
+    Ok(())
+}
+
+impl<A: Offset, B: Offset> From<&MultiPointArray<A>> for WKBArray<B> {
+    fn from(value: &MultiPointArray<A>) -> Self {
+        let mut offsets: Offsets<B> = Offsets::with_capacity(value.len());
+
+        // First pass: calculate binary array offsets
+        for maybe_geom in value.iter() {
+            if let Some(geom) = maybe_geom {
+                offsets.try_push_usize(multi_point_wkb_size(geom)).unwrap();
+            } else {
+                offsets.extend_constant(1);
+            }
+        }
+
+        let values = {
+            let values = Vec::with_capacity(offsets.last().to_usize());
+            let mut writer = Cursor::new(values);
+
+            for geom in value.iter().flatten() {
+                write_line_string_as_wkb(&mut writer, geom).unwrap();
+            }
+
+            writer.into_inner()
+        };
+
+        let data_type = match B::IS_LARGE {
+            true => DataType::LargeBinary,
+            false => DataType::Binary,
+        };
+
+        let binary_arr = BinaryArray::new(
+            data_type,
+            offsets.into(),
+            values.into(),
+            value.validity().cloned(),
+        );
+        WKBArray::new(binary_arr)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::test::multipoint::{mp0, mp1};
+
+    #[test]
+    fn round_trip() {
+        let orig_arr: MultiPointArray<i32> = vec![Some(mp0()), Some(mp1()), None].into();
+        let wkb_arr: WKBArray<i32> = (&orig_arr).into();
+        let new_arr: MultiPointArray<i32> = wkb_arr.try_into().unwrap();
+
+        assert_eq!(orig_arr, new_arr);
+    }
+}

--- a/src/io/wkb/writer/multipoint.rs
+++ b/src/io/wkb/writer/multipoint.rs
@@ -12,7 +12,7 @@ use byteorder::{LittleEndian, WriteBytesExt};
 use std::io::{Cursor, Write};
 
 /// The byte length of a WKBMultiPoint
-pub fn multi_point_wkb_size<'a>(geom: impl MultiPointTrait<'a>) -> usize {
+pub fn multi_point_wkb_size<'a>(geom: &impl MultiPointTrait<'a>) -> usize {
     1 + 4 + 4 + (geom.num_points() * POINT_WKB_SIZE)
 }
 
@@ -47,7 +47,7 @@ impl<A: Offset, B: Offset> From<&MultiPointArray<A>> for WKBArray<B> {
         // First pass: calculate binary array offsets
         for maybe_geom in value.iter() {
             if let Some(geom) = maybe_geom {
-                offsets.try_push_usize(multi_point_wkb_size(geom)).unwrap();
+                offsets.try_push_usize(multi_point_wkb_size(&geom)).unwrap();
             } else {
                 offsets.extend_constant(1);
             }

--- a/src/io/wkb/writer/multipoint.rs
+++ b/src/io/wkb/writer/multipoint.rs
@@ -16,8 +16,8 @@ pub fn multi_point_wkb_size<'a>(geom: impl MultiPointTrait<'a>) -> usize {
     1 + 4 + 4 + (geom.num_points() * POINT_WKB_SIZE)
 }
 
-/// Write a Point geometry to a Writer encoded as WKB
-pub fn write_line_string_as_wkb<'a, W: Write>(
+/// Write a MultiPoint geometry to a Writer encoded as WKB
+pub fn write_multi_point_as_wkb<'a, W: Write>(
     mut writer: W,
     geom: impl MultiPointTrait<'a, T = f64>,
 ) -> Result<()> {
@@ -58,7 +58,7 @@ impl<A: Offset, B: Offset> From<&MultiPointArray<A>> for WKBArray<B> {
             let mut writer = Cursor::new(values);
 
             for geom in value.iter().flatten() {
-                write_line_string_as_wkb(&mut writer, geom).unwrap();
+                write_multi_point_as_wkb(&mut writer, geom).unwrap();
             }
 
             writer.into_inner()

--- a/src/io/wkb/writer/multipolygon.rs
+++ b/src/io/wkb/writer/multipolygon.rs
@@ -12,18 +12,18 @@ use byteorder::{LittleEndian, WriteBytesExt};
 use std::io::{Cursor, Write};
 
 /// The byte length of a WKBMultiPolygon
-pub fn multi_polygon_wkb_size<'a>(geom: impl MultiPolygonTrait<'a>) -> usize {
+pub fn multi_polygon_wkb_size<'a>(geom: &impl MultiPolygonTrait<'a>) -> usize {
     let mut sum = 1 + 4 + 4;
     for polygon_idx in 0..geom.num_polygons() {
         let polygon = geom.polygon(polygon_idx).unwrap();
-        sum += polygon_wkb_size(polygon);
+        sum += polygon_wkb_size(&polygon);
     }
 
     sum
 }
 
-/// Write a MultiLineString geometry to a Writer encoded as WKB
-pub fn write_multi_line_string_as_wkb<'a, W: Write>(
+/// Write a MultiPolygon geometry to a Writer encoded as WKB
+pub fn write_multi_polygon_as_wkb<'a, W: Write>(
     mut writer: W,
     geom: impl MultiPolygonTrait<'a, T = f64>,
 ) -> Result<()> {
@@ -54,7 +54,7 @@ impl<A: Offset, B: Offset> From<&MultiPolygonArray<A>> for WKBArray<B> {
         for maybe_geom in value.iter() {
             if let Some(geom) = maybe_geom {
                 offsets
-                    .try_push_usize(multi_polygon_wkb_size(geom))
+                    .try_push_usize(multi_polygon_wkb_size(&geom))
                     .unwrap();
             } else {
                 offsets.extend_constant(1);
@@ -66,7 +66,7 @@ impl<A: Offset, B: Offset> From<&MultiPolygonArray<A>> for WKBArray<B> {
             let mut writer = Cursor::new(values);
 
             for geom in value.iter().flatten() {
-                write_multi_line_string_as_wkb(&mut writer, geom).unwrap();
+                write_multi_polygon_as_wkb(&mut writer, geom).unwrap();
             }
 
             writer.into_inner()

--- a/src/io/wkb/writer/multipolygon.rs
+++ b/src/io/wkb/writer/multipolygon.rs
@@ -1,0 +1,103 @@
+use crate::array::{MultiPolygonArray, WKBArray};
+use crate::error::Result;
+use crate::geo_traits::MultiPolygonTrait;
+use crate::io::wkb::reader::geometry::Endianness;
+use crate::io::wkb::writer::polygon::{polygon_wkb_size, write_polygon_as_wkb};
+use crate::trait_::GeometryArrayTrait;
+use arrow2::array::BinaryArray;
+use arrow2::datatypes::DataType;
+use arrow2::offset::Offsets;
+use arrow2::types::Offset;
+use byteorder::{LittleEndian, WriteBytesExt};
+use std::io::{Cursor, Write};
+
+/// The byte length of a WKBMultiPolygon
+pub fn multi_polygon_wkb_size<'a>(geom: impl MultiPolygonTrait<'a>) -> usize {
+    let mut sum = 1 + 4 + 4;
+    for polygon_idx in 0..geom.num_polygons() {
+        let polygon = geom.polygon(polygon_idx).unwrap();
+        sum += polygon_wkb_size(polygon);
+    }
+
+    sum
+}
+
+/// Write a MultiLineString geometry to a Writer encoded as WKB
+pub fn write_multi_line_string_as_wkb<'a, W: Write>(
+    mut writer: W,
+    geom: impl MultiPolygonTrait<'a, T = f64>,
+) -> Result<()> {
+    // Byte order
+    writer.write_u8(Endianness::LittleEndian.into()).unwrap();
+
+    // wkbType = 6
+    writer.write_u32::<LittleEndian>(6).unwrap();
+
+    // numPolygons
+    writer
+        .write_u32::<LittleEndian>(geom.num_polygons().try_into().unwrap())
+        .unwrap();
+
+    for polygon_idx in 0..geom.num_polygons() {
+        let polygon = geom.polygon(polygon_idx).unwrap();
+        write_polygon_as_wkb(&mut writer, polygon).unwrap();
+    }
+
+    Ok(())
+}
+
+impl<A: Offset, B: Offset> From<&MultiPolygonArray<A>> for WKBArray<B> {
+    fn from(value: &MultiPolygonArray<A>) -> Self {
+        let mut offsets: Offsets<B> = Offsets::with_capacity(value.len());
+
+        // First pass: calculate binary array offsets
+        for maybe_geom in value.iter() {
+            if let Some(geom) = maybe_geom {
+                offsets
+                    .try_push_usize(multi_polygon_wkb_size(geom))
+                    .unwrap();
+            } else {
+                offsets.extend_constant(1);
+            }
+        }
+
+        let values = {
+            let values = Vec::with_capacity(offsets.last().to_usize());
+            let mut writer = Cursor::new(values);
+
+            for geom in value.iter().flatten() {
+                write_multi_line_string_as_wkb(&mut writer, geom).unwrap();
+            }
+
+            writer.into_inner()
+        };
+
+        let data_type = match B::IS_LARGE {
+            true => DataType::LargeBinary,
+            false => DataType::Binary,
+        };
+
+        let binary_arr = BinaryArray::new(
+            data_type,
+            offsets.into(),
+            values.into(),
+            value.validity().cloned(),
+        );
+        WKBArray::new(binary_arr)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::test::multipolygon::{mp0, mp1};
+
+    #[test]
+    fn round_trip() {
+        let orig_arr: MultiPolygonArray<i32> = vec![Some(mp0()), Some(mp1()), None].into();
+        let wkb_arr: WKBArray<i32> = (&orig_arr).into();
+        let new_arr: MultiPolygonArray<i32> = wkb_arr.try_into().unwrap();
+
+        assert_eq!(orig_arr, new_arr);
+    }
+}

--- a/src/io/wkb/writer/point.rs
+++ b/src/io/wkb/writer/point.rs
@@ -1,0 +1,77 @@
+use arrow2::array::BinaryArray;
+use arrow2::datatypes::DataType;
+use arrow2::offset::Offsets;
+use arrow2::types::Offset;
+use byteorder::{LittleEndian, WriteBytesExt};
+
+use crate::array::{PointArray, WKBArray};
+use crate::error::Result;
+use crate::geo_traits::PointTrait;
+use crate::io::wkb::reader::geometry::Endianness;
+use crate::trait_::GeometryArrayTrait;
+use std::io::{Cursor, Write};
+
+/// The size of a WKBPoint
+pub const POINT_WKB_SIZE: usize = 1 + 4 + 8 + 8;
+
+/// Write a Point geometry to a Writer encoded as WKB
+pub fn write_point_as_wkb<W: Write>(mut writer: W, point: impl PointTrait<T = f64>) -> Result<()> {
+    // Byte order
+    writer.write_u8(Endianness::LittleEndian.into()).unwrap();
+
+    // wkbType = 1
+    writer.write_u32::<LittleEndian>(1).unwrap();
+
+    writer.write_f64::<LittleEndian>(point.x()).unwrap();
+    writer.write_f64::<LittleEndian>(point.y()).unwrap();
+
+    Ok(())
+}
+
+impl<O: Offset> From<&PointArray> for WKBArray<O> {
+    fn from(value: &PointArray) -> Self {
+        let non_null_count = value
+            .validity()
+            .map_or(value.len(), |validity| value.len() - validity.unset_bits());
+
+        let validity = value.validity().cloned();
+        // only allocate space for a WKBPoint for non-null items
+        let values_len = non_null_count * POINT_WKB_SIZE;
+        let mut offsets: Offsets<O> = Offsets::with_capacity(value.len());
+
+        let values = {
+            let values = Vec::with_capacity(values_len);
+            let mut writer = Cursor::new(values);
+
+            for geom in value.iter().flatten() {
+                write_point_as_wkb(&mut writer, geom).unwrap();
+                offsets.try_push_usize(POINT_WKB_SIZE).unwrap();
+            }
+
+            writer.into_inner()
+        };
+
+        let data_type = match O::IS_LARGE {
+            true => DataType::LargeBinary,
+            false => DataType::Binary,
+        };
+
+        let binary_arr = BinaryArray::new(data_type, offsets.into(), values.into(), validity);
+        WKBArray::new(binary_arr)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::test::point::{p0, p1, p2};
+
+    #[test]
+    fn round_trip() {
+        let orig_point_arr: PointArray = vec![Some(p0()), Some(p1()), Some(p2())].into();
+        let wkb_arr: WKBArray<i32> = (&orig_point_arr).into();
+        let new_point_arr: PointArray = wkb_arr.try_into().unwrap();
+
+        assert_eq!(orig_point_arr, new_point_arr);
+    }
+}

--- a/src/io/wkb/writer/point.rs
+++ b/src/io/wkb/writer/point.rs
@@ -1,29 +1,28 @@
-use arrow2::array::BinaryArray;
-use arrow2::datatypes::DataType;
-use arrow2::offset::Offsets;
-use arrow2::types::Offset;
-use byteorder::{LittleEndian, WriteBytesExt};
-
 use crate::array::{PointArray, WKBArray};
 use crate::error::Result;
 use crate::geo_traits::PointTrait;
 use crate::io::wkb::reader::geometry::Endianness;
 use crate::trait_::GeometryArrayTrait;
+use arrow2::array::BinaryArray;
+use arrow2::datatypes::DataType;
+use arrow2::offset::Offsets;
+use arrow2::types::Offset;
+use byteorder::{LittleEndian, WriteBytesExt};
 use std::io::{Cursor, Write};
 
-/// The size of a WKBPoint
+/// The byte length of a WKBPoint
 pub const POINT_WKB_SIZE: usize = 1 + 4 + 8 + 8;
 
 /// Write a Point geometry to a Writer encoded as WKB
-pub fn write_point_as_wkb<W: Write>(mut writer: W, point: impl PointTrait<T = f64>) -> Result<()> {
+pub fn write_point_as_wkb<W: Write>(mut writer: W, geom: impl PointTrait<T = f64>) -> Result<()> {
     // Byte order
     writer.write_u8(Endianness::LittleEndian.into()).unwrap();
 
     // wkbType = 1
     writer.write_u32::<LittleEndian>(1).unwrap();
 
-    writer.write_f64::<LittleEndian>(point.x()).unwrap();
-    writer.write_f64::<LittleEndian>(point.y()).unwrap();
+    writer.write_f64::<LittleEndian>(geom.x()).unwrap();
+    writer.write_f64::<LittleEndian>(geom.y()).unwrap();
 
     Ok(())
 }
@@ -68,10 +67,11 @@ mod test {
 
     #[test]
     fn round_trip() {
-        let orig_point_arr: PointArray = vec![Some(p0()), Some(p1()), Some(p2())].into();
-        let wkb_arr: WKBArray<i32> = (&orig_point_arr).into();
-        let new_point_arr: PointArray = wkb_arr.try_into().unwrap();
+        // TODO: test with nulls
+        let orig_arr: PointArray = vec![Some(p0()), Some(p1()), Some(p2())].into();
+        let wkb_arr: WKBArray<i32> = (&orig_arr).into();
+        let new_arr: PointArray = wkb_arr.try_into().unwrap();
 
-        assert_eq!(orig_point_arr, new_point_arr);
+        assert_eq!(orig_arr, new_arr);
     }
 }

--- a/src/io/wkb/writer/polygon.rs
+++ b/src/io/wkb/writer/polygon.rs
@@ -1,0 +1,147 @@
+use crate::array::{PolygonArray, WKBArray};
+use crate::error::Result;
+use crate::geo_traits::{CoordTrait, LineStringTrait, PolygonTrait};
+use crate::io::wkb::reader::geometry::Endianness;
+use crate::trait_::GeometryArrayTrait;
+use arrow2::array::BinaryArray;
+use arrow2::datatypes::DataType;
+use arrow2::offset::Offsets;
+use arrow2::types::Offset;
+use byteorder::{LittleEndian, WriteBytesExt};
+use std::io::{Cursor, Write};
+
+/// The byte length of a WKBPolygon
+pub fn polygon_wkb_size<'a>(geom: impl PolygonTrait<'a>) -> usize {
+    let mut sum = 1 + 4 + 4;
+
+    // TODO: support empty polygons where this will panic
+    let ext_ring = geom.exterior().unwrap();
+    sum += 4 + (ext_ring.num_coords() * 16);
+
+    for int_ring_idx in 0..geom.num_interiors() {
+        let int_ring = geom.interior(int_ring_idx).unwrap();
+        sum += 4 + (int_ring.num_coords() * 16);
+    }
+
+    dbg!(sum);
+    sum
+}
+
+/// Write a Polygon geometry to a Writer encoded as WKB
+pub fn write_polygon_as_wkb<'a, W: Write>(
+    mut writer: W,
+    geom: impl PolygonTrait<'a, T = f64>,
+) -> Result<()> {
+    // Byte order
+    writer.write_u8(Endianness::LittleEndian.into()).unwrap();
+
+    // wkbType = 3
+    writer.write_u32::<LittleEndian>(3).unwrap();
+
+    // numRings
+    // TODO: support empty polygons where this will panic
+    let num_rings = 1 + geom.num_interiors();
+    writer
+        .write_u32::<LittleEndian>(num_rings.try_into().unwrap())
+        .unwrap();
+
+    let ext_ring = geom.exterior().unwrap();
+    writer
+        .write_u32::<LittleEndian>(ext_ring.num_coords().try_into().unwrap())
+        .unwrap();
+
+    for coord_idx in 0..ext_ring.num_coords() {
+        let coord = ext_ring.coord(coord_idx).unwrap();
+        writer.write_f64::<LittleEndian>(coord.x()).unwrap();
+        writer.write_f64::<LittleEndian>(coord.y()).unwrap();
+    }
+
+    for int_ring_idx in 0..geom.num_interiors() {
+        let int_ring = geom.interior(int_ring_idx).unwrap();
+        writer
+            .write_u32::<LittleEndian>(int_ring.num_coords().try_into().unwrap())
+            .unwrap();
+
+        for coord_idx in 0..int_ring.num_coords() {
+            let coord = int_ring.coord(coord_idx).unwrap();
+            writer.write_f64::<LittleEndian>(coord.x()).unwrap();
+            writer.write_f64::<LittleEndian>(coord.y()).unwrap();
+        }
+    }
+
+    Ok(())
+}
+
+impl<A: Offset, B: Offset> From<&PolygonArray<A>> for WKBArray<B> {
+    fn from(value: &PolygonArray<A>) -> Self {
+        let mut offsets: Offsets<B> = Offsets::with_capacity(value.len());
+
+        // First pass: calculate binary array offsets
+        for maybe_geom in value.iter() {
+            if let Some(geom) = maybe_geom {
+                offsets.try_push_usize(polygon_wkb_size(geom)).unwrap();
+            } else {
+                offsets.extend_constant(1);
+            }
+        }
+
+        let values = {
+            let values = Vec::with_capacity(offsets.last().to_usize());
+            let mut writer = Cursor::new(values);
+
+            for geom in value.iter().flatten() {
+                write_polygon_as_wkb(&mut writer, geom).unwrap();
+            }
+
+            writer.into_inner()
+        };
+
+        let data_type = match B::IS_LARGE {
+            true => DataType::LargeBinary,
+            false => DataType::Binary,
+        };
+
+        let binary_arr = BinaryArray::new(
+            data_type,
+            offsets.into(),
+            values.into(),
+            value.validity().cloned(),
+        );
+        WKBArray::new(binary_arr)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::test::polygon::{p0, p1};
+    use geozero::{CoordDimensions, ToWkb};
+
+    #[test]
+    fn round_trip() {
+        let orig_arr: PolygonArray<i32> = vec![Some(p0()), Some(p1()), None].into();
+        let wkb_arr: WKBArray<i32> = (&orig_arr).into();
+        let new_arr: PolygonArray<i32> = wkb_arr.clone().try_into().unwrap();
+
+        let wkb0 = geo::Geometry::Polygon(p0())
+            .to_wkb(CoordDimensions::xy())
+            .unwrap();
+        let wkb1 = geo::Geometry::Polygon(p1())
+            .to_wkb(CoordDimensions::xy())
+            .unwrap();
+
+        assert_eq!(wkb_arr.value(0).as_ref(), &wkb0);
+        assert_eq!(wkb_arr.value(1).as_ref(), &wkb1);
+
+        assert_eq!(orig_arr, new_arr);
+    }
+
+    // // TODO: parsing WKBArray<i64> into LineStringArray<i32> not yet implemented
+    // fn round_trip_to_i64() {
+    //     let orig_arr: LineStringArray<i32> = vec![Some(ls0()), Some(ls1()), None].into();
+    //     let wkb_arr: WKBArray<i64> = (&orig_arr).into();
+    //     let new_arr: LineStringArray<i32> = wkb_arr.try_into().unwrap();
+
+    //     assert_eq!(orig_arr, new_arr);
+    // }
+}

--- a/src/io/wkb/writer/polygon.rs
+++ b/src/io/wkb/writer/polygon.rs
@@ -23,7 +23,6 @@ pub fn polygon_wkb_size<'a>(geom: impl PolygonTrait<'a>) -> usize {
         sum += 4 + (int_ring.num_coords() * 16);
     }
 
-    dbg!(sum);
     sum
 }
 

--- a/src/io/wkb/writer/polygon.rs
+++ b/src/io/wkb/writer/polygon.rs
@@ -11,7 +11,7 @@ use byteorder::{LittleEndian, WriteBytesExt};
 use std::io::{Cursor, Write};
 
 /// The byte length of a WKBPolygon
-pub fn polygon_wkb_size<'a>(geom: impl PolygonTrait<'a>) -> usize {
+pub fn polygon_wkb_size<'a>(geom: &impl PolygonTrait<'a>) -> usize {
     let mut sum = 1 + 4 + 4;
 
     // TODO: support empty polygons where this will panic
@@ -78,7 +78,7 @@ impl<A: Offset, B: Offset> From<&PolygonArray<A>> for WKBArray<B> {
         // First pass: calculate binary array offsets
         for maybe_geom in value.iter() {
             if let Some(geom) = maybe_geom {
-                offsets.try_push_usize(polygon_wkb_size(geom)).unwrap();
+                offsets.try_push_usize(polygon_wkb_size(&geom)).unwrap();
             } else {
                 offsets.extend_constant(1);
             }

--- a/src/scalar/binary/scalar.rs
+++ b/src/scalar/binary/scalar.rs
@@ -42,6 +42,12 @@ impl<'a, O: Offset> GeometryScalarTrait<'a> for WKB<'a, O> {
     }
 }
 
+impl<'a, O: Offset> AsRef<[u8]> for WKB<'a, O> {
+    fn as_ref(&self) -> &[u8] {
+        self.arr.value(self.geom_index)
+    }
+}
+
 #[cfg(feature = "geozero")]
 impl<O: Offset> From<WKB<'_, O>> for geo::Geometry {
     fn from(value: WKB<'_, O>) -> Self {


### PR DESCRIPTION
Implements fast WKB writing from arrays of geometries.

For converting from arrays of geometries to a `WKBArray`, this does a two-pass approach. First it loops over all geometries to compute the output size of the encoded WKB geometry, adding this number to the offset array. Then it instantiates a values array with this known size and writes WKB geometries into this array. So it's able to only provision memory once.
